### PR TITLE
add .git-blame-ignore-revs so format is not taken into account

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Use ruff format; https://github.com/openbraininstitute/neurodamus/pull/15
+5e5aec15bd1efe4abf5516e9023b66fdf661496a


### PR DESCRIPTION
* Requires local configuration if one wants to use it
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view