### PR TITLE
Remove compat types

### DIFF
--- a/docs/api/subpackages/utils.rst
+++ b/docs/api/subpackages/utils.rst
@@ -15,7 +15,6 @@ neurodamus.utils.compat
 
    .. autosummary::
       List
-      Map
       Vector
 
 

--- a/neurodamus/connection.py
+++ b/neurodamus/connection.py
@@ -527,7 +527,7 @@ class Connection(ConnectionBase):
         """
         is_inh = params_obj["synType"] < 100
         if self._mod_override is not None:
-            mod_override = self._mod_override.get("ModOverride").s
+            mod_override = self._mod_override.get("ModOverride")
             self._mod_overrides.add(mod_override)
             override_helper = mod_override + "Helper"
             helper_cls = getattr(Nd.h, override_helper)

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -295,7 +295,7 @@ class _SimConfig(object):
         if cls.cli_options.simulator:
             cls._parsed_run["Simulator"] = cls.cli_options.simulator
 
-        cls.run_conf = run_conf = cls._parsed_run.as_dict(parse_strings=True)
+        cls.run_conf = run_conf = cls._parsed_run
         for validator in cls._validators:
             validator(cls, run_conf)
 
@@ -323,12 +323,10 @@ class _SimConfig(object):
         """Init objects which parse/check configs in the hoc world"""
         from neuron import h
 
-        parsed_run = cls._parsed_run.hoc_map
-
         cls.rng_info = h.RNGSettings()
-        cls.rng_info.interpret(parsed_run, cls.use_coreneuron)
-        if parsed_run.exists("BaseSeed"):
-            logging.info("User-defined RNG base seed %s", parsed_run.valueOf("BaseSeed"))
+        cls.rng_info.interpret(cls._parsed_run, cls.use_coreneuron)
+        if cls._parsed_run.exists("BaseSeed"):
+            logging.info("User-defined RNG base seed %s", cls._parsed_run["BaseSeed"])
 
     @classmethod
     def validator(cls, f):

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -274,18 +274,18 @@ class _SimConfig(object):
         log_verbose("CLI Options: %s", cli_options)
         cls.config_file = config_file
         cls._config_parser = cls._init_config_parser(config_file)
-        cls._parsed_run = compat.Map(cls._config_parser.parsedRun)  # easy access to hoc Map
+        cls._parsed_run = cls._config_parser.parsedRun
         cls._simulation_config = cls._config_parser  # Please refactor me
         cls.sonata_circuits = cls._config_parser.circuits
         cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))
 
-        cls.projections = compat.Map(cls._config_parser.parsedProjections)
-        cls.connections = compat.Map(cls._config_parser.parsedConnects)
-        cls.stimuli = compat.Map(cls._config_parser.parsedStimuli)
-        cls.injects = compat.Map(cls._config_parser.parsedInjects)
-        cls.reports = compat.Map(cls._config_parser.parsedReports)
-        cls.configures = compat.Map(cls._config_parser.parsedConfigures or {})
-        cls.modifications = compat.Map(cls._config_parser.parsedModifications or {})
+        cls.projections = cls._config_parser.parsedProjections
+        cls.connections = cls._config_parser.parsedConnects
+        cls.stimuli = cls._config_parser.parsedStimuli
+        cls.injects = cls._config_parser.parsedInjects
+        cls.reports = cls._config_parser.parsedReports
+        cls.configures = cls._config_parser.parsedConfigures
+        cls.modifications = cls._config_parser.parsedModifications
         cls.beta_features = cls._config_parser.beta_features
         cls.cli_options = CliOptions(**(cli_options or {}))
         cls.dry_run = cls.cli_options.dry_run
@@ -362,7 +362,6 @@ class _SimConfig(object):
 
         new_connections = {}
         for name, conn in cls.connections.items():
-            conn = compat.Map(conn).as_dict(True)
             update_item(conn, "Source")
             update_item(conn, "Destination")
             if Feature.SpontMinis not in restrict_features:
@@ -381,7 +380,6 @@ class _SimConfig(object):
     @classmethod
     def get_stim_inject(cls, stim_name):
         for _, inject in cls.injects.items():
-            inject = compat.Map(inject).as_dict(parse_strings=True)
             if stim_name == inject["Stimulus"]:
                 return inject
         return None
@@ -512,8 +510,8 @@ def _projection_params(config: _SimConfig, run_conf):
     required_fields = ("Path",)
     non_negatives = ("PopulationID",)
     for name, proj in config.projections.items():
-        _check_params("Projection " + name, compat.Map(proj), required_fields, (), non_negatives)
-        _validate_file_extension(compat.Map(proj).get("Path"))
+        _check_params("Projection " + name, proj, required_fields, (), non_negatives)
+        _validate_file_extension(proj.get("Path"))
 
 
 @SimConfig.validator
@@ -580,7 +578,7 @@ def _stimulus_params(config: _SimConfig, run_conf):
     for name, stim in config.stimuli.items():
         _check_params(
             "Stimulus " + name,
-            compat.Map(stim),
+            stim,
             required_fields,
             numeric_fields,
             non_negatives,
@@ -596,7 +594,7 @@ def _modification_params(config: _SimConfig, run_conf):
         "Type",
     )
     for name, mod_block in config.modifications.items():
-        _check_params("Modification " + name, compat.Map(mod_block), required_fields, ())
+        _check_params("Modification " + name, mod_block, required_fields, ())
 
 
 def _make_circuit_config(config_dict, req_morphology=True):
@@ -1099,7 +1097,6 @@ def _report_vars(config: _SimConfig, run_conf):
     report_configs_dict = {}
 
     for rep_name, rep_config in config.reports.items():
-        rep_config = compat.Map(rep_config).as_dict(parse_strings=True)
         report_configs_dict[rep_name] = rep_config
 
         _check_params(
@@ -1229,9 +1226,7 @@ def check_connections_configure(SimConfig, target_manager):
             conn = conn.get("_overrides")
 
     logging.info("Checking Connection Configurations")
-    all_conn_blocks = [
-        compat.Map(conn).as_dict(parse_strings=True) for conn in SimConfig.connections.values()
-    ]
+    all_conn_blocks = [conn for conn in SimConfig.connections.values()]
 
     # On a first phase process only for t=0
     for name, conn_conf in zip(SimConfig.connections, all_conn_blocks):
@@ -1292,7 +1287,6 @@ def check_connections_configure(SimConfig, target_manager):
 def _input_resistance(config: _SimConfig, target_manager):
     prop = "@dynamics:input_resistance"
     for stim_name, stim in config.stimuli.items():
-        stim = compat.Map(stim).as_dict(parse_strings=True)
         stim_inject = config.get_stim_inject(stim_name)
         if stim_inject is None:
             continue  # not injected, do not care

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -30,7 +30,6 @@ from .stimulus_manager import StimulusManager
 from .modification_manager import ModificationManager
 from .neuromodulation_manager import NeuroModulationManager
 from .target_manager import TargetSpec, TargetManager
-from .utils import compat
 from .utils.logging import log_stage, log_verbose, log_all
 from .utils.memory import DryRunStats, trim_memory, pool_shrink, free_event_queues, print_mem_usage
 from .utils.timeit import TimerManager, timeit
@@ -619,7 +618,6 @@ class Node:
     def _load_projections(self, pname, projection, **kw):
         """Check for Projection blocks"""
         target_manager = self._target_manager
-        projection = compat.Map(projection).as_dict(True)
         ptype = projection.get("Type")  # None, GapJunctions, NeuroGlial, NeuroModulation...
         ptype_cls = EngineBase.connection_types.get(ptype)
         source_t = TargetSpec(projection.get("Source"))
@@ -707,7 +705,6 @@ class Node:
         has_extra_cellular = False
         stim_dict = {}
         for stim_name, stim in SimConfig.stimuli.items():
-            stim = compat.Map(stim)
             if stim_name in stim_dict:
                 raise ConfigurationError("Stimulus declared more than once: %s", stim_name)
             stim_dict[stim_name] = stim
@@ -766,10 +763,9 @@ class Node:
                 else stim.get("Pattern").s
             )
             if pattern == "SynapseReplay":
-                replay_dict[stim_name] = compat.Map(stim).as_dict(parse_strings=True)
+                replay_dict[stim_name] = stim
 
         for name, inject in SimConfig.injects.items():
-            inject = compat.Map(inject).as_dict(parse_strings=True)
             target = inject["Target"]
             source = inject.get("Source")
             stim_name = inject["Stimulus"]
@@ -850,8 +846,7 @@ class Node:
         log_stage("Enabling modifications...")
 
         mod_manager = ModificationManager(self._target_manager)
-        for name, mod in SimConfig.modifications.items():
-            mod_info = compat.Map(mod)
+        for name, mod_info in SimConfig.modifications.items():
             target_spec = TargetSpec(mod_info["Target"])
             logging.info(" * [MOD] %s: %s -> %s", name, mod_info["Type"], target_spec)
             mod_manager.interpret(target_spec, mod_info)

--- a/neurodamus/utils/compat.py
+++ b/neurodamus/utils/compat.py
@@ -5,11 +5,6 @@ Compatibility Classes to work similar to HOC types, recreating or wrapping them
 from __future__ import absolute_import
 from array import array
 
-try:
-    import collections.abc as collections_abc  # Py >= 3.3
-except ImportError:
-    import collections as collections_abc
-
 
 class Vector(array):
     """Behavior similar to Hoc Vector"""
@@ -45,124 +40,6 @@ class List(list):
 
     def o(self, idx):
         return self[int(idx)]
-
-
-class Map(collections_abc.Mapping):
-    """Class which bring Python map API to hoc Maps"""
-
-    __slots__ = ("_hoc_map", "_size", "String")
-
-    def __new__(cls, wrapped_obj, *args, **kwargs):
-        """If the wrapped entity is not an hoc map, but a Python dict
-        then also wrap it using PyMap for a similar API
-        """
-        if isinstance(wrapped_obj, dict):
-            return PyMap(wrapped_obj)
-        return object.__new__(cls)
-
-    def __init__(self, hoc_map):
-        self._hoc_map = hoc_map
-        self._size = int(hoc_map.count())
-        from neuron import h
-
-        self.String = h.String
-
-    def __iter__(self):
-        return (self._hoc_map.key(i).s for i in range(self._size))
-
-    def items(self):
-        return ((self._hoc_map.key(i).s, self._hoc_map.o(i)) for i in range(self._size))
-
-    def values(self):
-        return (self._hoc_map.o(i) for i in range(self._size))
-
-    keys = __iter__
-
-    def get(self, key, default=None):
-        return self[key] if key in self else default
-
-    def __getitem__(self, item):
-        value = self._hoc_map.get(item)
-        if hasattr(value, "s"):  # hoc strings have the value in .s attribute
-            value = value.s
-        return value
-
-    def __setitem__(self, key, value):
-        if self._hoc_map.exists(key):
-            self._hoc_map.get(key).s = str(value)
-        else:
-            self._hoc_map.put(key, self.String(str(value)))
-            self._size = int(self._hoc_map.count())  # update size
-
-    def update(self, other_map):
-        for key, val in other_map.items():
-            self[key] = val
-
-    def __contains__(self, item):
-        return self._hoc_map.exists(item) > 0
-
-    def __len__(self):
-        return self._size
-
-    @property
-    def hoc_map(self):
-        """Returns the raw hoc map"""
-        return self._hoc_map
-
-    def as_dict(self, parse_strings=False):
-        """Creates a real dictionary from the Map.
-
-        Args:
-            parse_strings: If true converts string objects in both key and values to
-                real strings (xx.s) and attempts to convert values to float
-        """
-        if parse_strings:
-
-            def parse(stri):
-                try:
-                    return float(stri)
-                except ValueError:
-                    return stri
-
-            new_map = {key: parse(val.s) for key, val in self.items()}
-        else:
-            new_map = dict(self)
-        new_map["_hoc"] = self.hoc_map
-        return new_map
-
-
-class PyMap(dict):
-    """
-    PyMap does basically the reverse of compat.Map: it's a true dict but capable of
-    getting a hoc map, built on the fly
-    """
-
-    __slots__ = ()
-
-    @property
-    def hoc_map(self):
-        """Returns the raw hoc map"""
-        return self._dict_as_hoc(self)
-
-    @classmethod
-    def _value_as_hoc(cls, value):
-        from neuron import h
-
-        if isinstance(value, dict):
-            return cls._dict_as_hoc(value)
-        return h.String(str(value))
-
-    @classmethod
-    def _dict_as_hoc(cls, d):
-        from neuron import h
-
-        m = h.Map()
-        for key, val in d.items():
-            m.put(h.String(key), cls._value_as_hoc(val))
-        return m
-
-    def as_dict(self, *_, **_kw):
-        return self
 
 
 def hoc_vector(np_array):

--- a/neurodamus/utils/multimap.py
+++ b/neurodamus/utils/multimap.py
@@ -5,7 +5,7 @@ A collection of Pure-Python MultiMaps
 import numpy as np
 from functools import reduce
 from operator import add
-from .compat import collections_abc
+import collections.abc as collections_abc
 
 
 class MultiMap(collections_abc.Mapping):


### PR DESCRIPTION
## Context
`Compat` types were designed to behavior similar to Hoc objects. It was necessary when neurodamus needed to parse the legacy config file (BlueConfig) as well as the SONATA config file. Now with the only SONATA case, it should be possible to replace them with python types.

## Scope
Remove `compat.py` which contains
- [ ] Compat.Vector
- [ ] Compat.List
   - [ ]  required by `ConnectionUtils.hoc`
- [x] Compat.Map
   - [ ] required by `RNGSetting.hoc`
- [ ] function `hoc_vector`

## Testing
<!--
Please add a new test under `tests`. Consider the following cases:

 1. If the change is in an independent component (e.g, a new container type, a parser, etc) a bare unit test should be sufficient. See e.g. `tests/test_coords.py`
 2. If you are fixing or adding components supporting a scientific use case, affecting node or synapse creation, etc..., which typically rely on Neuron, tests should set up a simulation using that feature, instantiate neurodamus, **assess the state**, run the simulation and check the results are as expected.
    See an example at `tests/test_simulation.py#L66`
-->

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
