### PR TITLE
do not use `from ._utils import *` to avoid polluting namespaces

### DIFF
--- a/neurodamus/core/__init__.py
+++ b/neurodamus/core/__init__.py
@@ -1,18 +1,37 @@
-# flake8: noqa
 """
 neurodamus.core
----------------
 
 The neurodamus.core package implements several helper modules for building circuits
 with Neuron.
 They can be seen as a High-Level Neuron API, and several examples are found under `examples`.
 """
 
-from __future__ import absolute_import
 from ._engine import EngineBase
 from ._neuron import Neuron
 from ._mpi import MPI, OtherRankError
 from ._neurodamus import NeurodamusCore
-from ._utils import *
+from ._utils import (
+    ProgressBarRank0,
+    run_only_rank0,
+    mpi_no_errors,
+    SimulationProgress,
+    return_neuron_timings,
+)
 from .cell import Cell
 from .stimuli import CurrentSource, ConductanceSource
+
+__all__ = [
+    "MPI",
+    "Cell",
+    "ConductanceSource",
+    "CurrentSource",
+    "EngineBase",
+    "NeurodamusCore",
+    "Neuron",
+    "OtherRankError",
+    "ProgressBarRank0",
+    "SimulationProgress",
+    "mpi_no_errors",
+    "return_neuron_timings",
+    "run_only_rank0",
+]


### PR DESCRIPTION
Now the imports that are used are explicit