### PR TITLE
Adds test for synapse replay with virtual population

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,11 +11,6 @@ RINGTEST_DIR = Path(__file__).parent.parent.absolute() / "simulations" / "ringte
 
 
 @pytest.fixture
-def ringtest_dir():
-    return RINGTEST_DIR
-
-
-@pytest.fixture
 def ringtest_baseconfig():
     return dict(
         network=str(RINGTEST_DIR / "circuit_config.json"),


### PR DESCRIPTION
## Context
Add a unit test using projections

Fixes #96 
## Scope
Based on the ring test simulation circuit test a replay synapse input changing RingA population type to virtual, testing that way the use of projections

## Testing
Extended and improved test_replay_manager 

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation