### PR TITLE
Apply workaround in CI for NMODL change

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -147,6 +147,16 @@ jobs:
         else
           git clone --branch=${{ env.NEURON_BRANCH }} https://github.com/neuronsimulator/nrn.git --depth=1
         fi
+        if [[ -d ${PWD}/nrn/external/nmodl ]]; then
+          git -C ${PWD}/nrn submodule update --init --recursive --depth=1 external/nmodl
+          # apply temp workaround for https://github.com/openbraininstitute/neurodamus/issues/3
+          patch="${PWD}/ci/0001-Revert-Use-aligned_alloc-as-we-do-in-CoreNEURON-too-.patch"
+          if git -C ${PWD}/nrn/external/nmodl apply "${patch}" >& /dev/null; then
+            echo "Successfully applied patch ${patch}"
+          else
+            echo "Failed to apply patch ${patch}; CI will continue as-is"
+          fi
+        fi
         python -m pip install --upgrade pip -r nrn/nrn_requirements.txt
         cmake -B nrn/build -S nrn -G Ninja \
           -DPYTHON_EXECUTABLE=$(which python) \

--- a/ci/0001-Revert-Use-aligned_alloc-as-we-do-in-CoreNEURON-too-.patch
+++ b/ci/0001-Revert-Use-aligned_alloc-as-we-do-in-CoreNEURON-too-.patch
@@ -1,0 +1,34 @@
+From 66791fc353535abe0a45ff00e0049e740962fa18 Mon Sep 17 00:00:00 2001
+From: Goran Jelic-Cizmek <goran.jelic-cizmek@epfl.ch>
+Date: Mon, 10 Mar 2025 13:37:09 +0100
+Subject: [PATCH] Revert "Use aligned_alloc as we do in CoreNEURON too (#933)"
+
+This reverts commit 3eab851dd4a31e6f8e082faf79d83d69b6482e2b.
+---
+ src/codegen/codegen_coreneuron_cpp_visitor.cpp | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/src/codegen/codegen_coreneuron_cpp_visitor.cpp b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+index c46ad2e..38e3f08 100644
+--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
++++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+@@ -297,12 +297,11 @@ bool CodegenCoreneuronCppVisitor::optimize_ion_variable_copies() const {
+ 
+ void CodegenCoreneuronCppVisitor::print_memory_allocation_routine() const {
+     printer->add_newline(2);
+-    auto args = "size_t num, size_t size, size_t alignment = 64";
++    auto args = "size_t num, size_t size, size_t alignment = 16";
+     printer->fmt_push_block("static inline void* mem_alloc({})", args);
+-    printer->add_line(
+-        "size_t aligned_size = ((num*size + alignment - 1) / alignment) * alignment;");
+-    printer->add_line("void* ptr = aligned_alloc(alignment, aligned_size);");
+-    printer->add_line("memset(ptr, 0, aligned_size);");
++    printer->add_line("void* ptr;");
++    printer->add_line("posix_memalign(&ptr, alignment, num*size);");
++    printer->add_line("memset(ptr, 0, size);");
+     printer->add_line("return ptr;");
+     printer->pop_block();
+ 
+-- 
+2.39.3 (Apple Git-145)
+

--- a/tests/scientific/test_lfp.py
+++ b/tests/scientific/test_lfp.py
@@ -188,13 +188,11 @@ def test_v5_sonata_lfp(test_file, tmp_path):
     nd.run()
 
     # compare results with refs
-    # t3_data = np.array([0.00027065672, -0.00086610153, 0.0014563566, -0.0046603414])
-    # t7_data = np.array([0.00029265403, -0.0009364929, 0.001548515, -0.004955248])
+    t3_data = np.array([0.00027065672, -0.00086610153, 0.0014563566, -0.0046603414])
+    t7_data = np.array([0.00029265403, -0.0009364929, 0.001548515, -0.004955248])
     node_ids = np.array([0, 4])
     result_ids, result_data = _read_sonata_lfp_file(Path(output_dir) / "lfp.h5")
 
-    # TODO: reenable after: https://github.com/openbraininstitute/neurodamus/issues/3
-    # is solved
-    # npt.assert_allclose(result_data.data[3], t3_data)
-    # npt.assert_allclose(result_data.data[7], t7_data)
+    npt.assert_allclose(result_data.data[3], t3_data)
+    npt.assert_allclose(result_data.data[7], t7_data)
     npt.assert_allclose(result_ids, node_ids)


### PR DESCRIPTION
## Context
<!-- Please brifly describe the problem the PR solves and what the solution was -->

(Possible) workaround for #3 (i.e. bring back the use of `posix_memalign` instead of `std::aligned_alloc` in NMODL, first introduced in https://github.com/BlueBrain/nmodl/pull/933). Note that NMODL is supposed to be integrated at some point in NEURON, so a more permanent fix should become available soon™️ (assuming this one actually works).

## Scope
<!--
Please describe in more detail the several changes implemented. How did we solve it?
E.g. change component-A to..., created a new data structure, etc...
-->

Apply a git patch to NMODL when running the CI.

## Testing
<!--
Please add a new test under `tests`. Consider the following cases:

 1. If the change is in an independent component (e.g, a new container type, a parser, etc) a bare unit test should be sufficient. See e.g. `tests/test_coords.py`
 2. If you are fixing or adding components supporting a scientific use case, affecting node or synapse creation, etc..., which typically rely on Neuron, tests should set up a simulation using that feature, instantiate neurodamus, **assess the state**, run the simulation and check the results are as expected.
    See an example at `tests/test_simulation.py#L66`
-->

Re-enable tests that were disabled in #51 due to #3.

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
