### PR TITLE
`Node.__init__`: split it into `__init__` and `_reset`

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -339,7 +339,8 @@ class Node:
             config_file: A Sonata config file
             options: A dictionary of run options typically coming from cmd line
         """
-        assert config_file, "bool(config_file) cannot be False"
+        assert isinstance(config_file, str), "`config_file` should be a string"
+        assert config_file, "`config_file` cannot be empty"
 
         if config_file.endswith("BlueConfig"):
             raise ConfigurationError(
@@ -404,7 +405,6 @@ class Node:
         self._report_list = None
         self._stim_manager = None
         self._sim_ready = False
-        self._jumpstarters = []
         self._cell_state_dump_t = None
         self._bbss = Nd.BBSaveState()
 
@@ -1605,7 +1605,7 @@ class Node:
 
         # Reset vars
         Nd.init()
-        Node._reset(self)
+        self._reset()
 
         # Clear BBSaveState
         self._bbss.ignore()

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -1604,7 +1604,6 @@ class Node:
             self._sonatareport_helper.clear()
 
         # Reset vars
-        Nd.init()
         self._reset()
 
         # Clear BBSaveState


### PR DESCRIPTION
## Context

`__init__` has an internal api where, if the config_file is None it just resets the internal variables. It is done mainly for multicycle runs. This goes against the SRP. In addition, users may still use this function in this way. This may create confusion.

## Scope

`__init__` has been split in `__init__` and `_reset`. `__init__` calls reset under the hood. The main advantages are that:

- `_reset` is clearly marked for internal use only
- `__init__` simply fails if the `config_file` is `None`
- SRP

Added also a nice docstrings for good measure

Fix: #103 

## Testing

Since this is refactoring and `__init__` is already tested this should not alter our tests and no additional tests should be required.



## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
