### PR TITLE
Fix test dry_run polluting ringtest folder

### DIFF
--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -98,11 +98,16 @@ def test_dry_run_distribute_cells():
     Path(("allocation_r2_c1.pkl.gz")).unlink(missing_ok=True)
 
 
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "simconfig_fixture": "ringtest_baseconfig",
+    },
+], indirect=True)
 @pytest.mark.forked
-def test_dry_run_dynamic_distribute():
+def test_dry_run_dynamic_distribute(create_tmp_simulation_config_file):
     from neurodamus import Neurodamus
 
-    nd = Neurodamus(str(RINGTEST_DIR / "simulation_config.json"),  dry_run=False, lb_mode="Memory",
+    nd = Neurodamus(create_tmp_simulation_config_file, dry_run=False, lb_mode="Memory",
                      num_target_ranks=1)
 
     rank_alloc, _, _ = nd._dry_run_stats.distribute_cells_with_validation(2, 1)


### PR DESCRIPTION
## Context
For #197, this PR just create a temporary simulation_config file in the temporary folder to let ringtest folder clean

## Scope
Every neurodamus initialization without dry_run activated generates "output/population_offset.dat" file in the same folder of the simulation config file by default. To solve the pollution of ringtest folder a temp simulation_config file is created in the tmp test folder 

## Testing
Fix test_dry_run

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit test added
