### PR TITLE
Add unit tests for CLI option --enable-shm

### DIFF
--- a/neurodamus/commands.py
+++ b/neurodamus/commands.py
@@ -55,7 +55,7 @@ def neurodamus(args=None):
         --save-time=<TIME>      The simulation time [ms] to save the state. (Default: At the end)
         --restore=<PATH>        Restore and resume simulation from a save point on disk
         --dump-cell-state=<GID> Dump cell state debug files on start, save-restore and at the end
-        --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: ON]
+        --enable-shm=[ON, OFF]  Enables the use of /dev/shm for coreneuron_input [default: OFF]
         --model-stats           Show model stats in CoreNEURON simulations [default: False]
         --dry-run               Dry-run simulation to estimate memory usage [default: False]
         --crash-test            Run the simulation with single section cells and single synapses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from pathlib import Path
+import platform
 
 # utils needs to be registered to let pytest rewrite
 # properly the assert errors. Either import it or use:
@@ -15,6 +16,7 @@ pytest.register_assert_rewrite("tests.utils")
 
 SIM_DIR = Path(__file__).parent.absolute() / "simulations"
 USECASE3 = SIM_DIR / "usecase3"
+PLATFORM_SYSTEM = platform.system()
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration-e2e/test_cli_opts.py
+++ b/tests/integration-e2e/test_cli_opts.py
@@ -159,39 +159,6 @@ def test_cli_build_model():
     assert "SIMULATION (SKIP MODEL BUILD)" in result_off.stdout
 
 
-def test_cli_shm_transfer():
-    with open(SIM_DIR / CONFIG_FILE_MINI, "r") as f:
-        sim_config_data = json.load(f)
-        sim_config_data["target_simulator"] = "CORENEURON"
-        sim_config_data["network"] = str(SIM_DIR / CIRCUIT_DIR / "circuit_config.json")
-
-    test_folder = tempfile.TemporaryDirectory("cli-test-shm-transfer")  # auto removed
-    test_folder_path = Path(test_folder.name)
-    with open(test_folder_path / CONFIG_FILE_MINI, "w") as f:
-        json.dump(sim_config_data, f, indent=2)
-
-    shm_transfer_message = "Unknown SHM directory for model file transfer in CoreNEURON."
-    shm_transfer_message_bb5 = "SHM file transfer mode for CoreNEURON enabled"
-    result_shm = subprocess.run(
-        ["neurodamus", CONFIG_FILE_MINI, "--enable-shm=ON"],
-        check=True,
-        cwd=test_folder_path,
-        capture_output=True,
-        text=True
-    )
-    assert shm_transfer_message in result_shm.stdout or \
-        shm_transfer_message_bb5 in result_shm.stdout
-    result_shm_off = subprocess.run(
-        ["neurodamus", CONFIG_FILE_MINI, "--enable-shm=OFF"],
-        check=True,
-        cwd=test_folder_path,
-        capture_output=True,
-        text=True
-    )
-    assert shm_transfer_message not in result_shm_off.stdout and \
-        shm_transfer_message_bb5 not in result_shm_off.stdout
-
-
 def test_cli_lb_mode():
     test_folder = tempfile.TemporaryDirectory("cli-test-lb-mode")  # auto removed
     test_folder_path = Path(test_folder.name)

--- a/tests/unit/test_cli_shm.py
+++ b/tests/unit/test_cli_shm.py
@@ -1,7 +1,8 @@
 """
 Tests for using POSIX shared memory /dev/shm for coreneuron_input,
 controlled by CLI option --enable-shm=[ON, OFF], default: OFF
-Prerequisite: an enviroment variable "SHMDIR" points to /dev/shm directory (only for linux)
+Prerequisites: an enviroment variable "SHMDIR" points to /dev/shm directory,
+    /dev/shm is only available in Linux.
 """
 
 

--- a/tests/unit/test_cli_shm.py
+++ b/tests/unit/test_cli_shm.py
@@ -1,0 +1,63 @@
+"""
+Tests for using POSIX shared memory /dev/shm for coreneuron_input,
+controlled by CLI option --enable-shm=[ON, OFF], default: OFF
+Prerequisite: an enviroment variable "SHMDIR" points to /dev/shm directory (only for linux)
+"""
+
+
+import os
+
+import pytest
+
+from tests.conftest import PLATFORM_SYSTEM
+
+from neurodamus import Neurodamus
+
+is_linux = PLATFORM_SYSTEM == "Linux"
+# if $SHMDIR not avaible, create one for this test
+if is_linux and "SHMDIR" not in os.environ:
+    os.environ["SHMDIR"] = "/dev/shm"
+
+
+@pytest.mark.parametrize(
+    "create_tmp_simulation_config_file",
+    [
+        {
+            "simconfig_fixture": "ringtest_baseconfig",
+            "extra_config": {"target_simulator": "CORENEURON"},
+        }
+    ],
+    indirect=True,
+)
+def test_cli_enableshm(create_tmp_simulation_config_file, capsys):
+    Neurodamus(create_tmp_simulation_config_file, enable_shm=True).run()
+    captured = capsys.readouterr()
+
+    shm_transfer_message_warning = "Unknown SHM directory for model file transfer in CoreNEURON."
+    shm_transfer_message_enabled = "SHM file transfer mode for CoreNEURON enabled"
+
+    if is_linux:
+        assert shm_transfer_message_enabled in captured.out
+    else:
+        assert shm_transfer_message_warning in captured.out
+
+
+@pytest.mark.parametrize(
+    "create_tmp_simulation_config_file",
+    [
+        {
+            "simconfig_fixture": "ringtest_baseconfig",
+            "extra_config": {"target_simulator": "CORENEURON"},
+        }
+    ],
+    indirect=True,
+)
+def test_cli_disableshm(create_tmp_simulation_config_file, capsys):
+    Neurodamus(create_tmp_simulation_config_file).run()
+    captured = capsys.readouterr()
+
+    shm_transfer_message_warning = "Unknown SHM directory for model file transfer in CoreNEURON."
+    shm_transfer_message_enabled = "SHM file transfer mode for CoreNEURON enabled"
+
+    assert shm_transfer_message_enabled not in captured.out
+    assert shm_transfer_message_warning not in captured.out

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -2,13 +2,12 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 import unittest.mock
-import platform
 import tempfile
 from pathlib import Path
 
 from tests.utils import defaultdict_to_standard_types
-from .conftest import RINGTEST_DIR
-from .conftest import NGV_DIR
+from .conftest import RINGTEST_DIR, NGV_DIR
+from ..conftest import PLATFORM_SYSTEM
 
 TMP_FOLDER = tempfile.mkdtemp()
 
@@ -30,7 +29,7 @@ def test_dry_run_memory_use():
 
     nd.run()
 
-    isMacOS = platform.system() == "Darwin"
+    isMacOS = PLATFORM_SYSTEM == "Darwin"
     assert (45.0 if isMacOS else 80.0) <= nd._dry_run_stats.base_memory <= (
         75.0 if isMacOS else 120.0)
     assert 0.4 <= nd._dry_run_stats.cell_memory_total <= 6.0


### PR DESCRIPTION
## Context
with --enable-shm=ON, we enable to write coreneuron_input directory in `/dev/shm` for better performance.
If the system doesn't have the `/dev/shm` directory, it falls back to normal location in `output_root`.
This PR adds unit tests for --enable-shm, and check behaviors in different platform systems (linux/macOS)

## Scope
To enable shm, neurodamus requires `--enable-shm` option, as well as `SHMDIR` env variable pointing to `/dev/shm`. In `tests/unit/test_cli_shm.py`, for linux, if `SHMDIR` doesn't exist we assign a value to it in order to test the shm usage.  This manual assignment is for test ONLY. In the actual run, `SHMDIR` should be created at the system level.

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
