### PR TITLE
Removes MEComboInfoFile

### DIFF
--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -98,7 +98,6 @@ class CircuitConfig(ConfigT):
     CircuitPath = ConfigT.REQUIRED
     nrnPath = ConfigT.REQUIRED
     CellLibraryFile = None
-    MEComboInfoFile = None
     METypePath = None
     MorphologyType = None
     MorphologyPath = None


### PR DESCRIPTION
## Context
This PR removes MEComboInfoFile used in BLueConfig and not used any more

Fix #175 

## Scope
Remove MEComboInfoFile from configuration.py

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
