### PR TITLE
Bump neuron version in the integration CI

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 env:
-  NEURON_COMMIT_ID: 'c48d7d5'
+  NEURON_COMMIT_ID: '7175203'
   RDMAV_FORK_SAFE: '1'
 
 jobs:

--- a/tests/integration-e2e/test_multicycle_runs.py
+++ b/tests/integration-e2e/test_multicycle_runs.py
@@ -29,16 +29,13 @@ def test_v5_sonata_multisteps(capsys, create_tmp_simulation_config_file):
     spike_gids = np.array([
         4, 2, 0
     ])  # 0-based
-    # timestamps = np.array([
-    #     33.425, 37.35, 39.725
-    # ])
+    timestamps = np.array([
+        33.425, 37.35, 39.725
+    ])
     spike_file = Path(nd._run_conf.get("OutputRoot")) / nd._run_conf.get("SpikesFile")
-    _obtained_timestamps, obtained_spike_gids = read_sonata_spike_file(spike_file)
+    obtained_timestamps, obtained_spike_gids = read_sonata_spike_file(spike_file)
     npt.assert_allclose(spike_gids, obtained_spike_gids)
-    # coreneuron and neuron have a discrepancy now:
-    # https://github.com/openbraininstitute/neurodamus/issues/44?issue=openbraininstitute%7Cneurodamus%7C3
-    # TODO: re-enable once it is fixed
-    # npt.assert_allclose(timestamps, obtained_timestamps)
+    npt.assert_allclose(timestamps, obtained_timestamps)
 
     captured = capsys.readouterr()
     assert "MULTI-CYCLE RUN: 3 Cycles" in captured.out

--- a/tests/scientific/test_lfp.py
+++ b/tests/scientific/test_lfp.py
@@ -188,13 +188,11 @@ def test_v5_sonata_lfp(test_file, tmp_path):
     nd.run()
 
     # compare results with refs
-    # t3_data = np.array([0.00027065672, -0.00086610153, 0.0014563566, -0.0046603414])
-    # t7_data = np.array([0.00029265403, -0.0009364929, 0.001548515, -0.004955248])
+    t3_data = np.array([0.00027065672, -0.00086610153, 0.0014563566, -0.0046603414])
+    t7_data = np.array([0.00029265403, -0.0009364929, 0.001548515, -0.004955248])
     node_ids = np.array([0, 4])
     result_ids, result_data = _read_sonata_lfp_file(Path(output_dir) / "lfp.h5")
 
-    # TODO: reenable after: https://github.com/openbraininstitute/neurodamus/issues/3
-    # is solved
-    # npt.assert_allclose(result_data.data[3], t3_data)
-    # npt.assert_allclose(result_data.data[7], t7_data)
+    npt.assert_allclose(result_data.data[3], t3_data)
+    npt.assert_allclose(result_data.data[7], t7_data)
     npt.assert_allclose(result_ids, node_ids)


### PR DESCRIPTION
## Context
As reported in #3, neuron commit `0e7570e50` leads to changes in translated mod files with ion concentration STATE vars for CoreNEURON, for which we saw changes in simulation reports with v5_sonata circuit. Neuron commit `7175203` has fixed the issue. This PR bumps the neuron commit ID to `7175203` in the integration/scientific CI tests.

## Scope
- `simulation_test.yml` : NEURON_COMMIT_ID: '7175203'
- integration tests: bring back the report comparisons in `test_v5_sonata_multisteps` and `test_v5_sonata_lfp`

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
