### PR TITLE
SpikeManager: remove legacy support

### DIFF
--- a/neurodamus/replay.py
+++ b/neurodamus/replay.py
@@ -1,5 +1,7 @@
 """Stimulus implementation where incoming synaptic events are replayed for a single gid"""
 
+from pathlib import Path
+
 from .core.configuration import ConfigurationError
 from .utils.multimap import GroupedMultiMap
 from .utils.timeit import timeit
@@ -37,7 +39,7 @@ class SpikeManager:
             filename: path to spike out file. Interpret as binary or ascii according to extension
             delay: delay to apply to spike times
         """
-        if filename.endswith(".h5"):
+        if Path(filename).suffix == (".h5"):
             tvec, gidvec = self._read_spikes_sonata(filename, population)
         else:
             raise ConfigurationError("Spikes input should be a SONATA h5 file")

--- a/neurodamus/replay.py
+++ b/neurodamus/replay.py
@@ -1,5 +1,6 @@
 """Stimulus implementation where incoming synaptic events are replayed for a single gid"""
 
+from .core.configuration import ConfigurationError
 from .utils.multimap import GroupedMultiMap
 from .utils.timeit import timeit
 
@@ -36,7 +37,10 @@ class SpikeManager:
             filename: path to spike out file. Interpret as binary or ascii according to extension
             delay: delay to apply to spike times
         """
-        tvec, gidvec = self._read_spikes_sonata(filename, population)
+        if filename.endswith(".h5"):
+            tvec, gidvec = self._read_spikes_sonata(filename, population)
+        else:
+            raise ConfigurationError("Spikes input should be a SONATA h5 file")
         if delay:
             tvec += delay
 

--- a/neurodamus/replay.py
+++ b/neurodamus/replay.py
@@ -1,11 +1,5 @@
 """Stimulus implementation where incoming synaptic events are replayed for a single gid"""
 
-import logging
-import os
-
-import numpy as np
-
-from .utils.logging import log_verbose
 from .utils.multimap import GroupedMultiMap
 from .utils.timeit import timeit
 
@@ -42,17 +36,7 @@ class SpikeManager:
             filename: path to spike out file. Interpret as binary or ascii according to extension
             delay: delay to apply to spike times
         """
-        # determine if we have binary or ascii file
-        # TODO: filename should be able to handle relative paths,
-        # using the Run.CurrentDir as an initial path
-        # _read_spikes_xxx shall return numpy arrays
-        if filename.endswith(".h5"):
-            tvec, gidvec = self._read_spikes_sonata(filename, population)
-        elif filename.endswith(".bin"):
-            tvec, gidvec = self._read_spikes_binary(filename)
-        else:
-            tvec, gidvec = self._read_spikes_ascii(filename)
-
+        tvec, gidvec = self._read_spikes_sonata(filename, population)
         if delay:
             tvec += delay
 
@@ -68,48 +52,6 @@ class SpikeManager:
         spikes = spikes_file[population]
         spike_dict = spikes.get_dict()
         return spike_dict["timestamps"], spike_dict["node_ids"] + 1
-
-    @classmethod
-    def _read_spikes_ascii(cls, filename):
-        log_verbose("Reading ascii spike file %s", filename)
-        # first line is '/scatter'
-        spikes = np.loadtxt(filename, dtype=cls._ascii_spike_dtype, skiprows=1, ndmin=1)
-
-        if len(spikes) > 0:
-            log_verbose("Loaded %d spikes", len(spikes))
-        else:
-            logging.warning("No spike/gid found in spike file %s", filename)
-
-        return spikes["time"], spikes["gid"]
-
-    @staticmethod
-    def _read_spikes_binary(filename):
-        """Read in the binary file with spike events.
-
-        Format notes: The first half of file is interpreted as double precision time values
-        followed by an equal number of double precision gid values.
-        File must be produced on the same architecture where NEURON will run (i.e. no byte-swapping)
-        Read the data on the root node, broadcasting info - This is fine as long as the entire data
-        set fits in a single node's memory. Should it become significantly larger, this could be
-        replaced with a distributed model where each node loads a portion of the file, and exchanges
-        with other nodes so as to ultimately hold data for local gids.
-        """
-        log_verbose("Reading Binary spike file %s", filename)
-        # there *should* be a number of doubles (8 bytes) such that
-        # it is divisible by 2 (half for time values, half for gids)
-        statinfo = os.stat(filename)
-        filesize = statinfo.st_size
-        n_events = filesize // 16
-        if not filesize % 16:
-            logging.warning("File size doesn't conform to have same number of gids and times")
-
-        with open(filename, "rb") as reader:
-            tvec = np.fromfile(reader, "d", n_events)
-            gidvec = np.fromfile(reader, "d", n_events).astype("uint32")
-
-        log_verbose("Replay: Loaded %d spikes", len(tvec))
-
-        return tvec, gidvec
 
     def _store_events(self, tvec, gidvec):
         """Stores the events in the _gid_fire_events GroupedMultiMap.
@@ -138,29 +80,6 @@ class SpikeManager:
     def filter_map(self, pre_gids):
         """Returns a raw dict of pre_gid->spikes for the given pre gids."""
         return {key: self._gid_fire_events[key] for key in pre_gids}
-
-    def dump_ascii(self, f, gid_offset=None):
-        """Writes the spikes out, in compat ascii format.
-
-        Args:
-            f: The file name or handle
-        """
-        gids, times = self._gid_fire_events.flatten().data()
-        if gid_offset:
-            log_verbose("dump_ascii: add offset %d to gids", gid_offset)
-            gids += gid_offset
-        expanded_ds = np.stack((times, gids), axis=-1)
-
-        if isinstance(f, str):
-            # If given a filename we assume a new file is wanted, with new header
-            with open(f, "w") as fx:
-                fx.write("/scatter\n")
-                np.savetxt(fx, expanded_ds, fmt="%.3lf\t%d")
-        else:
-            # If given a file handle, user wants control so we directly dump
-            np.savetxt(f, expanded_ds, fmt="%.3lf\t%d")
-
-        log_verbose("Replay: Written %d entries", len(expanded_ds))
 
 
 class MissingSpikesPopulationError(Exception):

--- a/tests/unit/test_replay_manager.py
+++ b/tests/unit/test_replay_manager.py
@@ -107,6 +107,14 @@ def test_sonata_spike_manager_with_delay():
     npt.assert_allclose(spike_manager.filter_map(pre_gids=[2, 3]).get(2), [10.175, 13.025, 15.7])
 
 
+def test_error_replay_format():
+    from neurodamus.core.configuration import ConfigurationError
+    from neurodamus.replay import SpikeManager
+
+    with pytest.raises(ConfigurationError, match="Spikes input should be a SONATA h5 file"):
+        SpikeManager("out.dat")
+
+
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
     {
         "simconfig_fixture": "ringtest_baseconfig",


### PR DESCRIPTION
## Context
As SONATA SPEC defines, the input spikes file for replay should be the SONATA .h5 format. This PR removes the support for legacy .bin and .dat files in `SpikeManager` class.

## Scope
Remove the relevant code in `replay.py`

## Testing
Add tests in `tests/unit/test_replay_manager.py`

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [x] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
