### PR TITLE
stop manipulating PYTHONPATH when possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ local_scheme = "no-local-version"
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = [
-    "--import-mode=importlib",
     "-vv",
     "-ra",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     {[testenv]deps}
     pytest-cov
 setenv =
-    PYTHONPATH={toxinidir}
     COVERAGE_FILE = .coverage.baseline
 commands =
     pytest --cov=neurodamus --cov-report=term-missing tests/test_import.py
@@ -26,7 +25,6 @@ deps =
     morphio
 setenv =
     NEURON_INIT_MPI=0
-    PYTHONPATH={toxinidir}
     COVERAGE_FILE = .coverage.unit
 allowlist_externals =
     {toxinidir}/ci/build_ndcore.sh
@@ -43,7 +41,6 @@ deps =
     neuron-nightly
     -r tests/unit-mpi/requirements.txt
 setenv =
-    PYTHONPATH={toxinidir}
     NEURON_INIT_MPI=1
     RDMAV_FORK_SAFE=1
     COVERAGE_FILE = .coverage.unit-mpi


### PR DESCRIPTION
setting the PYTHONPATH unnecessarily makes debugging harder; go back to the default pytest `--import-mode` system, since we don't have the repository layout that is recommended to use for the `importlib` (see https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#choosing-an-import-mode)