### PR TITLE
Fix --lb-mode=Memory

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -456,6 +456,16 @@ class Node:
             if file_exists:
                 alloc = self._dry_run_stats.import_allocation_stats(filename, self._cycle_i)
             else:
+                if not (
+                    Path(DryRunStats._MEMORY_USAGE_FILENAME).exists()
+                    and Path(DryRunStats._MEMORY_USAGE_PER_METYPE_FILENAME).exists()
+                ):
+                    raise RuntimeError(
+                        f"No files {DryRunStats._MEMORY_USAGE_FILENAME} or "
+                        f"{DryRunStats._MEMORY_USAGE_PER_METYPE_FILENAME}. Neurodamus must be run "
+                        "in Dry_run mode before proceeding."
+                    )
+
                 logging.warning("Allocation file not found. Generating on-the-fly.")
                 self._dry_run_stats.try_import_cell_memory_usage()
                 cell_distributor = CellDistributor(circuit, self._target_manager, self._run_conf)

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -99,7 +99,7 @@ def test_dry_run_distribute_cells():
     },
 ], indirect=True)
 @pytest.mark.forked
-def test_dry_run_dynamic_distribute(create_tmp_simulation_config_file):
+def test_dry_run_lb_mode_memory(create_tmp_simulation_config_file):
     nd = Neurodamus(create_tmp_simulation_config_file, dry_run=False, lb_mode="Memory",
                      num_target_ranks=1)
 
@@ -112,6 +112,25 @@ def test_dry_run_dynamic_distribute(create_tmp_simulation_config_file):
         }
     }
     assert rank_allocation_standard == expected_allocation
+
+    Path("allocation_r1_c1.pkl.gz").unlink(missing_ok=True)
+    Path("allocation_r2_c1.pkl.gz").unlink(missing_ok=True)
+    Path("cell_memory_usage.json").unlink(missing_ok=True)
+    Path("memory_per_metype.json").unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "simconfig_fixture": "ringtest_baseconfig",
+    },
+], indirect=True)
+@pytest.mark.forked
+def test_dry_run_lb_mode_memory_fail(create_tmp_simulation_config_file):
+    with pytest.raises(RuntimeError,
+                       match="No files cell_memory_usage.json or memory_per_metype.json. "
+                       "Neurodamus must be run in Dry_run mode before proceeding."):
+        Neurodamus(create_tmp_simulation_config_file, dry_run=False, lb_mode="Memory",
+                     num_target_ranks=1)
 
 
 @pytest.mark.forked


### PR DESCRIPTION
## Context
lb-mode Memory is failing when no cell_memory_usage.json or memory_per_metype.json commoning from dry_run are present.

Fix #243 

## Scope
Add dry_run memory files exists check and throw an error if not informing the user he must dry_run first
Add test for this situation

## Testing
Extent tests/unit/test_dry_run.py

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
