### PR TITLE
Adds load balance modes test

### DIFF
--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -245,10 +245,10 @@ class CellManagerBase(_CellManager):
 
         population = targetspec.population
         if population in load_balancer:
-            all_gids = load_balancer.get(population, {}).get((MPI.rank, cycle_i), [])
+            all_gids = load_balancer.get(population).get((MPI.rank, cycle_i), [])
             all_gids = np.array(all_gids, dtype="uint32")
-            logging.debug("Loading %d cells in rank %d", len(all_gids), MPI.rank)
             total_cells = len(all_gids)
+            logging.debug("Loading %d cells in rank %d", total_cells, MPI.rank)
             if total_cells == 0:
                 return [], [], 0, 0
             gidvec, me_infos, full_size = loader_f(self._circuit_conf, all_gids)

--- a/neurodamus/cell_distributor.py
+++ b/neurodamus/cell_distributor.py
@@ -244,14 +244,16 @@ class CellManagerBase(_CellManager):
         targetspec: TargetSpec = self._target_spec
 
         population = targetspec.population
-        all_gids = load_balancer.get(population, {}).get((MPI.rank, cycle_i), [])
-        all_gids = np.array(all_gids, dtype="uint32")
-        logging.debug("Loading %d cells in rank %d", len(all_gids), MPI.rank)
-        total_cells = len(all_gids)
-        if total_cells == 0:
-            return [], [], 0, 0
-        gidvec, me_infos, full_size = loader_f(self._circuit_conf, all_gids)
-        return gidvec, me_infos, total_cells, full_size
+        if population in load_balancer:
+            all_gids = load_balancer.get(population, {}).get((MPI.rank, cycle_i), [])
+            all_gids = np.array(all_gids, dtype="uint32")
+            logging.debug("Loading %d cells in rank %d", len(all_gids), MPI.rank)
+            total_cells = len(all_gids)
+            if total_cells == 0:
+                return [], [], 0, 0
+            gidvec, me_infos, full_size = loader_f(self._circuit_conf, all_gids)
+            return gidvec, me_infos, total_cells, full_size
+        return self._load_nodes(loader_f)
 
     # -
     def finalize(self, **opts):

--- a/tests/unit-mpi/test_loadbalance.py
+++ b/tests/unit-mpi/test_loadbalance.py
@@ -1,0 +1,108 @@
+import pytest
+import numpy as np
+import numpy.testing as npt
+from tests import utils
+from mpi4py import MPI
+import tempfile
+
+from neurodamus import Neurodamus
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+
+@pytest.fixture(scope="function")
+def tmp_folder():
+    if rank == 0:
+        path = tempfile.mkdtemp()
+    else:
+        path = None
+    # Broadcast to all ranks
+    path = comm.bcast(path, root=0)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def change_test_dir(monkeypatch, tmp_folder):
+    """
+    All tests in this file are using the same working directory, i.e tmp_folder
+    Because for lb_modes WholeCell and MultiSplit requires distribution data files to be shared
+    between all ranks
+    """
+    monkeypatch.chdir(tmp_folder)
+
+
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "simconfig_fixture": "ringtest_baseconfig",
+        "extra_config": {
+            "inputs": {
+                "Stimulus": {
+                    "module": "pulse",
+                    "input_type": "current_clamp",
+                    "delay": 5,
+                    "duration": 50,
+                    "node_set": "RingA",
+                    "represents_physical_electrode": True,
+                    "amp_start": 10,
+                    "width": 1,
+                    "frequency": 50
+                }
+            }
+        }
+    },
+], indirect=True)
+@pytest.mark.parametrize("lb_mode", [
+    "rr",
+    "roundrobin",
+    "wholecell",
+    "loadbalance",
+    "multisplit",
+    "memory",
+])
+@pytest.mark.mpi(ranks=2)
+def test_load_balance_simulation(create_tmp_simulation_config_file, copy_memory_files, lb_mode,
+                                 mpi_ranks):
+    from neurodamus.core import NeuronWrapper as Nd
+
+    nd = Neurodamus(create_tmp_simulation_config_file, lb_mode=lb_mode, num_target_ranks=mpi_ranks)
+
+    if rank == 0:
+        cell_id = 1001
+        manager = nd.circuits.get_node_manager("RingB")
+        cell_ringB = manager.get_cell(cell_id)
+        voltage_vec = Nd.Vector()
+        voltage_vec.record(cell_ringB._cellref.soma[0](0.5)._ref_v)
+
+    Nd.finitialize()
+    nd.run()
+
+    spike_gid_ref = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
+    timestamps_ref = np.array([5.1, 5.1, 5.1, 25.1, 25.1, 25.1, 45.1, 45.1, 45.1])
+    voltage_peaks_ref = np.array([92, 291])
+
+    # Get spikes in RingA population for every rank
+    ringA_spikes = nd._spike_vecs[0]
+    timestamps = np.array(ringA_spikes[0])
+    spike_gids = np.array(ringA_spikes[1])
+
+    # Combine spike information from all ranks
+    gathered_timestamps = comm.gather(timestamps, root=0)
+    gathered_gids = comm.gather(spike_gids, root=0)
+    if rank == 0:
+        timestamps = np.concatenate(gathered_timestamps)
+        spike_gids = np.concatenate(gathered_gids)
+
+        combined = np.core.records.fromarrays([timestamps, spike_gids], names='timestamp, gid')
+        sorted_combined = np.sort(combined, order=['timestamp', 'gid'])
+
+        timestamps = sorted_combined.timestamp
+        spike_gids = sorted_combined.gid
+
+        # Check spikes in RingA population
+        npt.assert_equal(spike_gid_ref, spike_gids)
+        npt.assert_allclose(timestamps_ref, timestamps)
+
+        # Check voltage variation in RingB population cell
+        utils.check_signal_peaks(voltage_vec, voltage_peaks_ref)

--- a/tests/unit/test_loadbalance.py
+++ b/tests/unit/test_loadbalance.py
@@ -4,14 +4,10 @@ import logging
 import re
 import shutil
 import pytest
-import numpy as np
-import numpy.testing as npt
 from pathlib import Path
-from tests import utils
 
 
 from tests.conftest import RINGTEST_DIR
-from neurodamus import Neurodamus
 from neurodamus.core.configuration import ConfigurationError, LoadBalanceMode
 
 base_dir = Path("sim_conf")
@@ -264,61 +260,6 @@ def test_WholeCell_bigcell(target_manager, circuit_conf_bigcell, capsys):
     cpu_assign_filename = next(Path(".").glob(str(base_dir / pattern / "cx_RingA_All#.2.dat")))
     content = Path(cpu_assign_filename).open().read()
     assert content == "msgid 10000000\nnhost 2\n0 1  0 1 0\n1 2  1 2 0  2 3 0\n"
-
-
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
-    {
-        "simconfig_fixture": "ringtest_baseconfig",
-        "extra_config": {
-            "inputs": {
-                "Stimulus": {
-                    "module": "pulse",
-                    "input_type": "current_clamp",
-                    "delay": 5,
-                    "duration": 50,
-                    "node_set": "RingA",
-                    "represents_physical_electrode": True,
-                    "amp_start": 10,
-                    "width": 1,
-                    "frequency": 50
-                }
-            }
-        }
-    },
-], indirect=True)
-@pytest.mark.parametrize("lb_mode", [
-    "rr",
-    "roundrobin",
-    "wholecell",
-    "loadbalance",
-    "multisplit",
-    "memory",
-])
-def test_load_balance_simulation(create_tmp_simulation_config_file, copy_memory_files, lb_mode):
-    from neurodamus.core import NeuronWrapper as Nd
-
-    nd = Neurodamus(create_tmp_simulation_config_file, lb_mode=lb_mode)
-
-    cell_id = 1001
-    manager = nd.circuits.get_node_manager("RingB")
-    cell_ringB = manager.get_cell(cell_id)
-    voltage_vec = Nd.Vector()
-    voltage_vec.record(cell_ringB._cellref.soma[0](0.5)._ref_v)
-
-    Nd.finitialize()
-    nd.run()
-
-    # Check spikes in RingA population
-    ringA_spikes = nd._spike_vecs[0]
-    timestamps = np.array(ringA_spikes[0])
-    spike_gids = np.array(ringA_spikes[1])
-    spike_gid_ref = np.array([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    timestamps_ref = np.array([5.1, 5.1, 5.1, 25.1, 25.1, 25.1, 45.1, 45.1, 45.1])
-    npt.assert_equal(spike_gid_ref, spike_gids)
-    npt.assert_allclose(timestamps_ref, timestamps)
-
-    # Check voltage variation in RingB population cell
-    utils.check_signal_peaks(voltage_vec, [92, 291])
 
 
 class MockedTargetManager:


### PR DESCRIPTION
## Context
It is needed to add tests running ringtest circuit simulation to check results are consistent between the different load balance modes. It is also needed to fix the load balance memory method to make it work with several population. 

Fix #289 
Fix #290 

## Scope
Adds tests to ensure consistency between the different load balance modes using ringtest circuit. Fix load balance memory mode instantiation for all the populations

## Testing
Expand unit test_loadbalance.py

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
