### PR TITLE
Extent load balance memory to distribute cells of every population

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -469,7 +469,7 @@ class Node:
                 logging.warning("Allocation file not found. Generating on-the-fly.")
                 self._dry_run_stats.try_import_cell_memory_usage()
                 for circuit in self._sonata_circuits.values():
-                    if circuit.get("PopulationType") != "virtual":
+                    if circuit.get("PopulationType") == "biophysical":
                         cell_distributor = CellDistributor(
                             circuit, self._target_manager, self._run_conf
                         )

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -468,14 +468,18 @@ class Node:
 
                 logging.warning("Allocation file not found. Generating on-the-fly.")
                 self._dry_run_stats.try_import_cell_memory_usage()
-                cell_distributor = CellDistributor(circuit, self._target_manager, self._run_conf)
-                cell_distributor.load_nodes(
-                    None,
-                    loader_opts={
-                        "load_mode": "load_nodes_metype",
-                        "dry_run_stats": self._dry_run_stats,
-                    },
-                )
+                for circuit in self._sonata_circuits.values():
+                    if circuit.get("PopulationType") != "virtual":
+                        cell_distributor = CellDistributor(
+                            circuit, self._target_manager, self._run_conf
+                        )
+                        cell_distributor.load_nodes(
+                            None,
+                            loader_opts={
+                                "load_mode": "load_nodes_metype",
+                                "dry_run_stats": self._dry_run_stats,
+                            },
+                        )
                 alloc, _, _ = self._dry_run_stats.distribute_cells_with_validation(
                     MPI.size,
                     SimConfig.modelbuilding_steps,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,9 +94,10 @@ def change_test_dir(monkeypatch, tmp_path):
 def copy_memory_files(change_test_dir):
     # Fix values to ensure allocation memory (0,0)[1, 3] (1,0)[2]
     metypes_memory = {
-        "MTYPE0-ETYPE0": 100.0,
+        "MTYPE0-ETYPE0": 1000.0,
+        "MTYPE0-ETYPE1": 100.0,
         "MTYPE1-ETYPE1": 200.0,
-        "MTYPE2-ETYPE2": 1000.0,
+        "MTYPE2-ETYPE2": 200.0,
     }
     with Path("memory_per_metype.json").open("w") as f:
         json.dump(metypes_memory, f, indent=4)

--- a/tests/unit-mpi/test_dry_run.py
+++ b/tests/unit-mpi/test_dry_run.py
@@ -96,17 +96,16 @@ def test_dry_run_distribute_cells(create_tmp_simulation_config_file, mpi_ranks):
     rank_alloc = nd._dry_run_stats.import_allocation_stats(nd._dry_run_stats._ALLOCATION_FILENAME
                                                             + "_r1_c1.pkl.gz", 0, True)
     rank_allocation_standard = defaultdict_to_standard_types(rank_alloc)
-    if rank == 0:
-        expected_allocation = {
+    expected_allocation = [
+        {
             'RingA': {(0, 0): [1, 2, 3]},
             'RingB': {(0, 0): [1, 2]}
-        }
-    elif rank == 1:
-        expected_allocation = {
+        },
+        {
             'RingA': {},
             'RingB': {}
-        }
-    assert rank_allocation_standard == expected_allocation
+        }]
+    assert rank_allocation_standard == expected_allocation[rank]
 
 
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
@@ -126,10 +125,8 @@ def test_dry_run_dynamic_distribute(create_tmp_simulation_config_file, mpi_ranks
     rank_allocation_standard = defaultdict_to_standard_types(rank_alloc)
 
     # Test allocation
-    # RingA neuron 1 always in rank 0, neuron 2 always in rank 1
-    # but neuron 3 can be in  either of the two
-    if rank == 0:
-        expected_allocation = {'RingA': {(0, 0): [1, 3]}}
-    elif rank == 1:
-        expected_allocation = {'RingA': {(1, 0): [2]}}
-    assert rank_allocation_standard == expected_allocation
+    expected_allocation = [
+        {'RingA': {(0, 0): [1]}, 'RingB': {(0, 0): [1]}},
+        {'RingA': {(1, 0): [2, 3]}, 'RingB': {(1, 0): [2]}}
+        ]
+    assert rank_allocation_standard == expected_allocation[rank]

--- a/tests/unit/test_dry_run.py
+++ b/tests/unit/test_dry_run.py
@@ -101,7 +101,11 @@ def test_dry_run_lb_mode_memory(create_tmp_simulation_config_file, copy_memory_f
     rank_allocation_standard = defaultdict_to_standard_types(rank_alloc)
     expected_allocation = {
         'RingA': {
-            (0, 0): [1, 3],
+            (0, 0): [1],
+            (1, 0): [2, 3]
+        },
+        'RingB': {
+            (0, 0): [1],
             (1, 0): [2]
         }
     }


### PR DESCRIPTION
## Context
Current load balance memory mode is focused in the distribution of the cells of the first circuit/population. 

Fix #291 

## Scope
Extent load balance memory mode to distribute the cells of every population

## Testing
Modified dry_run tests from unit and unit-mpi to ensure the load_balance memory distribution gives a different result from round robin distribution

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added