### PR TITLE
`test_reports.py`: use conftest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def ringtest_baseconfig():
 @pytest.fixture
 def v5_sonata_config():
     config_path = V5_SONATA / "simulation_config_mini.json"
-    with open(config_path) as f:
+    with open(config_path, "r") as f:
         d = json.load(f)
     d["network"] = str(V5_SONATA / "sub_mini5" / "circuit_config.json")
     return d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ pytest.register_assert_rewrite("tests.utils")
 
 SIM_DIR = Path(__file__).parent.absolute() / "simulations"
 USECASE3 = SIM_DIR / "usecase3"
+V5_SONATA = SIM_DIR / "v5_sonata"
 PLATFORM_SYSTEM = platform.system()
 RINGTEST_DIR = Path(__file__).parent.absolute() / "simulations" / "ringtest"
 NGV_DIR = Path(__file__).parent.absolute() / "simulations" / "ngv"
@@ -81,6 +82,14 @@ def ringtest_baseconfig():
             "v_init": -65
         }
     )
+
+@pytest.fixture
+def v5_sonata_config():
+    config_path = V5_SONATA / "simulation_config_mini.json"
+    with open(config_path) as f:
+        d = json.load(f)
+    d["network"] = str(V5_SONATA / "sub_mini5" / "circuit_config.json")
+    return d
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -14,70 +14,50 @@ def _read_sonata_report(report_file):
     data = report[pop_name].get()
     return node_ids, data
 
-
-def _create_reports_config(original_config_path: Path, tmp_path: Path) -> tuple[Path, Path]:
-    """
-    Create a modified configuration file in a temporary directory.
-    """
-    # Read the original config file
-    with open(original_config_path, 'r') as f:
-        config = json.load(f)
-
-    # Update the network path in the config
-    config["network"] = str(SIM_DIR / "sub_mini5" / "circuit_config.json")
-
-    # Modify the necessary fields
-    config["reports"] = config.get("reports", {})
-    config["reports"]["summation_report"] = {
-        "type": "summation",
-        "cells": "Mosaic",
-        "variable_name": "i_membrane,IClamp",
-        "sections": "all",
-        "dt": 0.1,
-        "start_time": 0.0,
-        "end_time": 40.0
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "simconfig_fixture": "v5_sonata_config",
+        "extra_config": {
+            "node_set": "Mosaic",
+            "reports": {
+                "summation_report": {
+                    "type": "summation",
+                    "cells": "Mosaic",
+                    "variable_name": "i_membrane,IClamp",
+                    "sections": "all",
+                    "dt": 0.1,
+                    "start_time": 0.0,
+                    "end_time": 40.0
+                },
+                "synapse_report" : {
+                    "type": "synapse",
+                    "cells": "Mosaic",
+                    "variable_name": "ProbAMPANMDA_EMS.g",
+                    "sections": "all",
+                    "dt": 0.1,
+                    "start_time": 0.0,
+                    "end_time": 40.0
+                },
+                "summation_ProbGABAAB": {
+                    "type": "summation",
+                    "cells": "Mosaic",
+                    "variable_name": "ProbGABAAB_EMS.i",
+                    "sections": "all",
+                    "dt": 0.1,
+                    "start_time": 0.0,
+                    "end_time": 40.0
+                }
+            }
+        }
     }
-    config["reports"]["synapse_report"] = {
-        "type": "synapse",
-        "cells": "Mosaic",
-        "variable_name": "ProbAMPANMDA_EMS.g",
-        "sections": "all",
-        "dt": 0.1,
-        "start_time": 0.0,
-        "end_time": 40.0
-    }
-    # Added to verify no exception is raised when point process is not present in a section
-    config["reports"]["summation_ProbGABAAB"] = {
-        "type": "summation",
-        "cells": "Mosaic",
-        "variable_name": "ProbGABAAB_EMS.i",
-        "sections": "all",
-        "dt": 0.1,
-        "start_time": 0.0,
-        "end_time": 40.0
-    }
-
-    # Write the modified configuration to a temporary file in tmp_path
-    temp_config_path = tmp_path / "reports_config.json"
-    with open(temp_config_path, "w") as f:
-        json.dump(config, f, indent=4)
-
-    output_dir = Path(config["output"]["output_dir"])
-    if not output_dir.is_absolute():
-        output_dir = tmp_path / output_dir
-
-    return str(temp_config_path), str(output_dir)
-
-
+], indirect=True)
 @pytest.mark.slow
-def test_v5_sonata_reports(tmp_path):
+def test_v5_sonata_reports(create_tmp_simulation_config_file):
     import numpy.testing as npt
     from neurodamus import Neurodamus
+    from neurodamus.core.configuration import SimConfig
 
-    config_file = SIM_DIR / "simulation_config_mini.json"
-    temp_config_path, output_dir = _create_reports_config(config_file, tmp_path)
-
-    nd = Neurodamus(temp_config_path)
+    nd = Neurodamus(create_tmp_simulation_config_file)
     nd.run()
 
     report_refs = {
@@ -90,7 +70,7 @@ def test_v5_sonata_reports(tmp_path):
 
     # Go through each report and compare the results
     for report_name, refs in report_refs.items():
-        result_ids, result_data = _read_sonata_report(Path(output_dir) / report_name)
+        result_ids, result_data = _read_sonata_report(Path(SimConfig.output_root) / report_name)
         assert result_ids == node_id_refs
         for row, col, ref in refs:
             npt.assert_allclose(result_data.data[row][col], ref)

--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -5,6 +5,7 @@ import libsonata
 import numpy.testing as npt
 import pytest
 
+from neurodamus import Neurodamus
 from neurodamus.core.configuration import SimConfig
 
 
@@ -54,8 +55,6 @@ def _read_sonata_report(report_file):
 ], indirect=True)
 @pytest.mark.slow
 def test_v5_sonata_reports(create_tmp_simulation_config_file):
-    from neurodamus import Neurodamus
-
     nd = Neurodamus(create_tmp_simulation_config_file)
     nd.run()
 

--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -1,13 +1,14 @@
-import json
-import pytest
+
 from pathlib import Path
 
+import libsonata
+import numpy.testing as npt
+import pytest
 
-SIM_DIR = Path(__file__).parent.parent.absolute() / "simulations" / "v5_sonata"
+from neurodamus.core.configuration import SimConfig
 
 
 def _read_sonata_report(report_file):
-    import libsonata
     report = libsonata.ElementReportReader(report_file)
     pop_name = report.get_population_names()[0]
     node_ids = report[pop_name].get_node_ids()
@@ -53,9 +54,7 @@ def _read_sonata_report(report_file):
 ], indirect=True)
 @pytest.mark.slow
 def test_v5_sonata_reports(create_tmp_simulation_config_file):
-    import numpy.testing as npt
     from neurodamus import Neurodamus
-    from neurodamus.core.configuration import SimConfig
 
     nd = Neurodamus(create_tmp_simulation_config_file)
     nd.run()


### PR DESCRIPTION
Fix: #314

## Context
`test_reports.py` was using a custom config based on v5_sonata

## Scope
we use the same config but modified with the standard fixtures in conftest.py

## Testing
the old tests work. This modification should not change the results and does not need additional tessts

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
