### PR TITLE
hotfix: mpi4py broke compatibility with openMPI 4

### DIFF
--- a/tests/unit-mpi/requirements.txt
+++ b/tests/unit-mpi/requirements.txt
@@ -1,1 +1,2 @@
 pytest-isolate-mpi
+mpi4py<=4.0.3 # Must match OpenMPI 4 (uses libmpi.so.12). 4.1+ passed to OpenMPI 5.


### PR DESCRIPTION
mpi4py 4.1.0 relies on OpenMPI 5 and fails with openMPI 4. For now, we disable the latest version of mpi4py
