### PR TITLE
CI: build and test simulation toolchain with macOS-15

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,11 +8,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-15]
-      fail-fast: false
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -23,18 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip tox coverage
-
-      - name: Install dependencies for ${{ matrix.os }}
-        run: |
-          if [[ $RUNNER_OS == 'Linux' ]]; then
-            sudo apt-get update
-            sudo apt-get install -y libopenmpi-dev openmpi-bin
-          elif [[ $RUNNER_OS == 'macOS' ]]; then
-            # Install MPI and Python dependencies for macOS
-            brew update
-            brew install open-mpi
-          fi
+          sudo apt-get update
+          sudo apt-get install -y libopenmpi-dev openmpi-bin
           python -m pip install --upgrade pip tox coverage
 
       - name: Run tox baseline
@@ -54,7 +40,6 @@ jobs:
           tox -e unit-mpi
 
       - name: Upload baseline coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +48,6 @@ jobs:
           parallel: true
 
       - name: Upload unit coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +56,6 @@ jobs:
           parallel: true
 
       - name: Upload unit-ngv-mpi coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +64,6 @@ jobs:
           parallel: true
 
       - name: Upload unit-mpi coverage to Coveralls
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -34,8 +34,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
+        include:
+        - os: ubuntu-22.04
+          python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
+        - os: macOS-15
+          python-version: ['3.12.6'] # because of the actions cache limit, test with one python version
       fail-fast: false
 
     steps:
@@ -80,9 +83,19 @@ jobs:
         if [[ ! -z $LIBSONATA_BRANCH ]]; then echo "LIBSONATA_BRANCH=$LIBSONATA_BRANCH" >> $GITHUB_ENV; fi
 
     - name: Install system dependencies
+      if: statswith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install -y mpich libmpich-dev libhdf5-mpich-dev hdf5-tools flex libfl-dev bison ninja-build
+
+    - name: Install homebrew packages
+      if: statswith(matrix.os, 'maxOS')
+      run: |
+        brew install hdf5-mpi openmpi  # macOS hdf5-mpi requires openmpi
+        brew install ccache coreutils doxygen flex bison ninja xz autoconf automake libtool
+        # NRN: workaround for fmt 11.1 (see https://github.com/gabime/spdlog/pull/3312)
+        brew unlink fmt
+        echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
     - name: Cache python virtual env
       id: cache-venv
@@ -170,8 +183,14 @@ jobs:
 
     - name: Build h5py with the local hdf5
       run: |
-        CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/mpich HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich \
-          pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
+        if [[ "${{matrix.os}}" == *"macOS"* ]]; then
+          export HDF5_INCLUDEDIR=$(brew --prefix hdf5-mpi)/include
+          export HDF5_LIBDIR=$(brew --prefix hdf5-mpi)/lib
+        else
+          export HDF5_INCLUDEDIR=/usr/include/hdf5/mpich
+          export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
+        fi
+        CC="mpicc" HDF5_MPI="ON" pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 
     - name: Install neurodamus
       run: |
@@ -201,8 +220,13 @@ jobs:
         export PYTHONPATH=$(pwd)/nrn/build/install/lib/python:$PYTHONPATH
         export HOC_LIBRARY_PATH=$NEURODAMUS_NEOCORTEX_ROOT/share/neurodamus_neocortex/hoc
         export NEURODAMUS_PYTHON=$(pwd)/neurodamus/data
-        export CORENEURONLIB=$NEURODAMUS_NEOCORTEX_ROOT/lib/libcorenrnmech.so
-        export NRNMECH_LIB_PATH=$NEURODAMUS_NEOCORTEX_ROOT/lib/libnrnmech.so
+        if [[ "${{matrix.os}}" == *"macOS"* ]]; then
+          export CORENEURONLIB=$NEURODAMUS_NEOCORTEX_ROOT/lib/libcorenrnmech.dylib
+          export NRNMECH_LIB_PATH=$NEURODAMUS_NEOCORTEX_ROOT/lib/libnrnmech.dylib
+        else
+          export CORENEURONLIB=$NEURODAMUS_NEOCORTEX_ROOT/lib/libcorenrnmech.so
+          export NRNMECH_LIB_PATH=$NEURODAMUS_NEOCORTEX_ROOT/lib/libnrnmech.so
+        fi
         export PATH=$NEURODAMUS_NEOCORTEX_ROOT/bin:$PATH
 
         echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV;

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -46,7 +46,7 @@ jobs:
           # macOS is only run with Python 3.12.6 due to github action cache size limits
           - os: macOS-15
             python-version: '3.12.6'
-      fail-fast: true
+      fail-fast: false
 
     steps:
     - name: Setup Python
@@ -59,14 +59,6 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
-
-    # - name: Cache pip
-    #   uses: actions/cache@v3
-    #   with:
-    #     path: ~/.cache/pip
-    #     key: ${{ matrix.os }}-pip-${{ matrix.python-version }}-v1
-    #     restore-keys: |
-    #       ${{ matrix.os }}-pip-
 
     - name: Get latest tags
       env:
@@ -106,17 +98,7 @@ jobs:
         brew unlink fmt
         echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
-    # - name: Cache python virtual env
-    #   id: cache-venv
-    #   uses: actions/cache@v3
-    #   env:
-    #     cache-name: cache-venv
-    #   with:
-    #     path: venv
-    #     key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
-
     - name: Upgrade pip and install base Python packages
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
@@ -126,8 +108,7 @@ jobs:
     - name: Add virtual environment to PATH
       run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
 
-    - name: Install libsonata
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
+    - name: Install libsonata from source
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/openbraininstitute/libsonata@${{ env.LIBSONATA_BRANCH }}
 
@@ -186,7 +167,6 @@ jobs:
         cmake --build nrn/build --target install
 
     - name: Install mpi4py
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         MPICC=mpicc pip install --no-binary=mpi4py mpi4py
 
@@ -283,8 +263,8 @@ jobs:
       run: |
         tox -e scientific
 
-    - name: live debug session, comment out
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      with:
-       timeout-minutes: 60  # or any other value you need
+    # - name: live debug session, comment out
+    #   if: failure()
+    #   uses: mxschmitt/action-tmate@v3
+    #   with:
+    #    timeout-minutes: 60  # or any other value you need

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -83,13 +83,13 @@ jobs:
         if [[ ! -z $LIBSONATA_BRANCH ]]; then echo "LIBSONATA_BRANCH=$LIBSONATA_BRANCH" >> $GITHUB_ENV; fi
 
     - name: Install system dependencies
-      if: statswith(matrix.os, 'ubuntu')
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install -y mpich libmpich-dev libhdf5-mpich-dev hdf5-tools flex libfl-dev bison ninja-build
 
     - name: Install homebrew packages
-      if: statswith(matrix.os, 'maxOS')
+      if: startsWith(matrix.os, 'maxOS')
       run: |
         brew install hdf5-mpi openmpi  # macOS hdf5-mpi requires openmpi
         brew install ccache coreutils doxygen flex bison ninja xz autoconf automake libtool

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -106,17 +106,17 @@ jobs:
         brew unlink fmt
         echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
-    # - name: Cache python virtual env
-    #   id: cache-venv
-    #   uses: actions/cache@v3
-    #   env:
-    #     cache-name: cache-venv
-    #   with:
-    #     path: venv
-    #     key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
+    - name: Cache python virtual env
+      id: cache-venv
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-venv
+      with:
+        path: venv
+        key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
 
     - name: Upgrade pip and install base Python packages
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
@@ -127,7 +127,7 @@ jobs:
       run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
 
     - name: Install libsonata
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/openbraininstitute/libsonata@${{ env.LIBSONATA_BRANCH }}
 
@@ -186,7 +186,7 @@ jobs:
         cmake --build nrn/build --target install
 
     - name: Install mpi4py
-      # if: steps.cache-venv.outputs.cache-hit != 'true'
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         pip install mpi4py
 
@@ -199,7 +199,8 @@ jobs:
           export HDF5_INCLUDEDIR=/usr/include/hdf5/mpich
           export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
         fi
-        CC="mpicc" HDF5_MPI="ON" pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
+        CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=$HDF5_INCLUDEDIR HDF5_LIBDIR=$HDF5_LIBDIR \
+          pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 
     - name: Install neurodamus
       run: |

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -45,7 +45,7 @@ jobs:
             python-version: '3.12.6'
           # macOS is only run with Python 3.12.6 due to github action cache size limits
           - os: macOS-15
-            python-version: '3.12.6'
+            python-version: '3.11.10'
       fail-fast: true
 
     steps:

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -46,7 +46,7 @@ jobs:
           # macOS is only run with Python 3.12.6 due to github action cache size limits
           - os: macOS-15
             python-version: '3.12.6'
-      fail-fast: false
+      fail-fast: true
 
     steps:
     - name: Setup Python
@@ -280,8 +280,8 @@ jobs:
       run: |
         tox -e scientific
 
-    # - name: live debug session, comment out
-    #   if: failure()
-    #   uses: mxschmitt/action-tmate@v3
-    #   with:
-    #    timeout-minutes: 60  # or any other value you need
+    - name: live debug session, comment out
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      with:
+       timeout-minutes: 60  # or any other value you need

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -69,7 +69,7 @@ jobs:
           ${{ matrix.os }}-pip-
 
     - name: Get latest tags
-      - env:
+      env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "NEURON_BRANCH=${{ inputs.NEURON_BRANCH || github.event.inputs.NEURON_BRANCH || 'master' }}" >> $GITHUB_ENV

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -41,7 +41,7 @@ jobs:
     # because of the cache limit in actions, we run macOS only with Python 3.12.6
     if: >
       startsWith(matrix.os, 'ubuntu') ||
-      (startsWith(matrix.os, 'macOS' && matrix.python-version == '3.12.6')
+      (startsWith(matrix.os, 'macOS') && matrix.python-version == '3.12.6')
 
     steps:
     - name: Setup Python

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -45,7 +45,7 @@ jobs:
             python-version: '3.12.6'
           # macOS is only run with Python 3.12.6 due to github action cache size limits
           - os: macOS-15
-            python-version: '3.11.10'
+            python-version: '3.12.6'
       fail-fast: true
 
     steps:
@@ -106,17 +106,17 @@ jobs:
         brew unlink fmt
         echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
-    - name: Cache python virtual env
-      id: cache-venv
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-venv
-      with:
-        path: venv
-        key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
+    # - name: Cache python virtual env
+    #   id: cache-venv
+    #   uses: actions/cache@v3
+    #   env:
+    #     cache-name: cache-venv
+    #   with:
+    #     path: venv
+    #     key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
 
     - name: Upgrade pip and install base Python packages
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
@@ -127,7 +127,7 @@ jobs:
       run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
 
     - name: Install libsonata
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/openbraininstitute/libsonata@${{ env.LIBSONATA_BRANCH }}
 
@@ -186,7 +186,7 @@ jobs:
         cmake --build nrn/build --target install
 
     - name: Install mpi4py
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         pip install mpi4py
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'neurodamus/**'
+      - 'tests/**'
+      - '.github/workflows/**'
+      - 'ci/**'
+      - 'pyproject.toml'
+      - 'tox.ini'
+      - 'requirements.txt'
   push:
     branches:
       - main

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -34,12 +34,14 @@ jobs:
 
     strategy:
       matrix:
-        include:
-        - os: ubuntu-22.04
-          python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
-        - os: macOS-15
-          python-version: ['3.12.6'] # because of the actions cache limit, test with one python version
+        os: [ubuntu-22.04, macOS-15]
+        python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
       fail-fast: false
+
+    # because of the cache limit in actions, we run macOS only with Python 3.12.6
+    if: >
+      startsWith(matrix.os, 'ubuntu') ||
+      (startsWith(matrix.os, 'macOS' && matrix.python-version == '3.12.6')
 
     steps:
     - name: Setup Python

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -106,7 +106,17 @@ jobs:
         brew unlink fmt
         echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
+    - name: Cache python virtual env
+      id: cache-venv
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-venv
+      with:
+        path: venv
+        key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
+
     - name: Upgrade pip and install base Python packages
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
@@ -117,6 +127,7 @@ jobs:
       run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
 
     - name: Install libsonata from source
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/openbraininstitute/libsonata@${{ env.LIBSONATA_BRANCH }}
 
@@ -175,6 +186,7 @@ jobs:
         cmake --build nrn/build --target install
 
     - name: Install mpi4py
+      if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         MPICC=mpicc pip install --no-binary=mpi4py mpi4py
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -34,14 +34,19 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macOS-15]
-        python-version: ['3.9.20', '3.10.15', '3.11.10', '3.12.6']
+        include:
+          - os: ubuntu-22.04
+            python-version: '3.9.20'
+          - os: ubuntu-22.04
+            python-version: '3.10.15'
+          - os: ubuntu-22.04
+            python-version: '3.11.10'
+          - os: ubuntu-22.04
+            python-version: '3.12.6'
+          # macOS is only run with Python 3.12.6 due to github action cache size limits
+          - os: macOS-15
+            python-version: '3.12.6'
       fail-fast: false
-
-    # because of the cache limit in actions, we run macOS only with Python 3.12.6
-    if: >
-      startsWith(matrix.os, 'ubuntu') ||
-      (startsWith(matrix.os, 'macOS') && matrix.python-version == '3.12.6')
 
     steps:
     - name: Setup Python

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -60,13 +60,13 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
-    - name: Cache pip
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ matrix.os }}-pip-${{ matrix.python-version }}-v1
-        restore-keys: |
-          ${{ matrix.os }}-pip-
+    # - name: Cache pip
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: ~/.cache/pip
+    #     key: ${{ matrix.os }}-pip-${{ matrix.python-version }}-v1
+    #     restore-keys: |
+    #       ${{ matrix.os }}-pip-
 
     - name: Get latest tags
       env:
@@ -106,17 +106,17 @@ jobs:
         brew unlink fmt
         echo "$(brew --prefix)/opt/flex/bin:$(brew --prefix)/opt/bison/bin" >> $GITHUB_PATH
 
-    - name: Cache python virtual env
-      id: cache-venv
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-venv
-      with:
-        path: venv
-        key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
+    # - name: Cache python virtual env
+    #   id: cache-venv
+    #   uses: actions/cache@v3
+    #   env:
+    #     cache-name: cache-venv
+    #   with:
+    #     path: venv
+    #     key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ matrix.python-version }}
 
     - name: Upgrade pip and install base Python packages
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         python -m venv venv
         . ./venv/bin/activate
@@ -127,7 +127,7 @@ jobs:
       run: echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
 
     - name: Install libsonata
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         CC=mpicc CXX=mpic++ pip install git+https://github.com/openbraininstitute/libsonata@${{ env.LIBSONATA_BRANCH }}
 
@@ -186,7 +186,7 @@ jobs:
         cmake --build nrn/build --target install
 
     - name: Install mpi4py
-      if: steps.cache-venv.outputs.cache-hit != 'true'
+      # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
         pip install mpi4py
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -96,7 +96,7 @@ jobs:
         sudo apt-get install -y mpich libmpich-dev libhdf5-mpich-dev hdf5-tools flex libfl-dev bison ninja-build
 
     - name: Install homebrew packages
-      if: startsWith(matrix.os, 'maxOS')
+      if: startsWith(matrix.os, 'macOS')
       run: |
         brew install hdf5-mpi openmpi  # macOS hdf5-mpi requires openmpi
         brew install ccache coreutils doxygen flex bison ninja xz autoconf automake libtool

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -69,13 +69,15 @@ jobs:
           ${{ matrix.os }}-pip-
 
     - name: Get latest tags
+      - env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "NEURON_BRANCH=${{ inputs.NEURON_BRANCH || github.event.inputs.NEURON_BRANCH || 'master' }}" >> $GITHUB_ENV
-        LIBSONATA_LATEST=$(curl -s https://api.github.com/repos/openbraininstitute/libsonata/tags | jq -r '.[0].name')
+        LIBSONATA_LATEST=$(curl --request GET --url https://api.github.com/repos/openbraininstitute/libsonata/tags --header "Authorization: Bearer $GH_TOKEN" | jq -r '.[0].name')
         echo "LIBSONATA_BRANCH=${{ inputs.LIBSONATA_BRANCH || github.event.inputs.LIBSONATA_BRANCH || '$LIBSONATA_LATEST' }}" >> $GITHUB_ENV
-        LIBSONATA_REPORT_LATEST=$(curl -s https://api.github.com/repos/openbraininstitute/libsonatareport/tags | jq -r '.[0].name')
+        LIBSONATA_REPORT_LATEST=$(curl --request GET --url https://api.github.com/repos/openbraininstitute/libsonatareport/tags --header "Authorization: Bearer $GH_TOKEN" | jq -r '.[0].name')
         echo "LIBSONATA_REPORT_BRANCH=${{ inputs.LIBSONATA_REPORT_BRANCH || github.event.inputs.LIBSONATA_REPORT_BRANCH || '$LIBSONATA_REPORT_LATEST' }}" >> $GITHUB_ENV
-        NEURODAMUS_MODELS_LATEST=$(curl -s https://api.github.com/repos/openbraininstitute/neurodamus-models/tags | jq -r '.[0].name')
+        NEURODAMUS_MODELS_LATEST=$(curl --request GET --url https://api.github.com/repos/openbraininstitute/neurodamus-models/tags --header "Authorization: Bearer $GH_TOKEN" | jq -r '.[0].name')
         echo "NEURODAMUS_MODELS_BRANCH=${{ inputs.NEURODAMUS_MODELS_BRANCH || github.event.inputs.NEURODAMUS_MODELS_BRANCH || '$NEURODAMUS_MODELS_LATEST' }}" >> $GITHUB_ENV
 
     - name: Get HEAD commit message and look for branches

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -199,6 +199,7 @@ jobs:
           export HDF5_INCLUDEDIR=/usr/include/hdf5/mpich
           export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
         fi
+        python -m pip install --upgrade pip setuptools
         CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=$HDF5_INCLUDEDIR HDF5_LIBDIR=$HDF5_LIBDIR \
           pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -91,13 +91,13 @@ jobs:
         LIBSONATA_BRANCH=$(echo $COMMIT_MESSAGE | grep -Po 'LIBSONATA_BRANCH=\K[0-9a-zA-Z/_.\-]*' || true)
         if [[ ! -z $LIBSONATA_BRANCH ]]; then echo "LIBSONATA_BRANCH=$LIBSONATA_BRANCH" >> $GITHUB_ENV; fi
 
-    - name: Install system dependencies
+    - name: Install ubuntu system dependencies
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install -y mpich libmpich-dev libhdf5-mpich-dev hdf5-tools flex libfl-dev bison ninja-build
 
-    - name: Install homebrew packages
+    - name: Install macOS homebrew packages
       if: startsWith(matrix.os, 'macOS')
       run: |
         brew install hdf5-mpi openmpi  # macOS hdf5-mpi requires openmpi
@@ -188,7 +188,7 @@ jobs:
     - name: Install mpi4py
       # if: steps.cache-venv.outputs.cache-hit != 'true'
       run: |
-        pip install mpi4py
+        MPICC=mpicc pip install --no-binary=mpi4py mpi4py
 
     - name: Build h5py with the local hdf5
       run: |
@@ -199,7 +199,6 @@ jobs:
           export HDF5_INCLUDEDIR=/usr/include/hdf5/mpich
           export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
         fi
-        python -m pip install --upgrade pip setuptools
         CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=$HDF5_INCLUDEDIR HDF5_LIBDIR=$HDF5_LIBDIR \
           pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 


### PR DESCRIPTION
## Context
Add `macOS-15` in `simulation_test.yml` to test the build and run unit tests.

## Scope
- `macOS-15` with python 3.12.6. We could test more python versions in macOS but there is the cache limit in GH actions, so choose one python version atm.
- remove the action cache for python virtual env. The cache is built for the python version and the libsonata tag used in the pipeline, but it won't rebuild if any python package in the venv is updated. And `pip install` is fast to build all required packages so we don't gain much (1-2 mins) with cache.
- remove `macOS` test in `coverage.yml`

## Review
* [x] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
