### PR TITLE
real `report.conf` loader

### DIFF
--- a/tests/unit/test_coreneuron_save_restore.py
+++ b/tests/unit/test_coreneuron_save_restore.py
@@ -54,37 +54,6 @@ def check_dir_content(dir, files):
         if f.name not in files:
             raise FileNotFoundError(f"File {f.name} exists in {dir} but is not expected.")
 
-
-def check_report_conf(checkpoint_dir, substitutions):
-    """
-    Check that the report.conf file in the checkpoint directory
-    has the expected end times.
-    """
-    found_keys = set()
-    file_path = Path(checkpoint_dir) / "report.conf"
-    with open(file_path, "rb") as f:
-        lines = f.readlines()
-        for line in lines:
-            try:
-
-                parts = line.decode().split()
-                key = tuple(parts[0:2])  # Report name and target name
-
-                if key in substitutions:
-                    assert float(parts[9]) == pytest.approx(float(substitutions[key])), (
-                        f"End time for {key} is not {substitutions[key]} in report.conf. "
-                        f"It is {parts[9]} instead."
-                    )
-                    found_keys.add(key)
-            except (UnicodeDecodeError, IndexError):
-                # Ignore lines that cannot be decoded (binary data)
-                continue
-    # Check that all expected keys were found
-    if len(substitutions) != len(found_keys):
-        missing_keys = set(substitutions.keys()) - found_keys
-        raise KeyError(f"The following keys were not found in {file_path}: {missing_keys}")
-
-
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
@@ -290,8 +259,9 @@ def test_full_run_vs_save_restore(create_tmp_simulation_config_file):
     subprocess.run(command, check=True, capture_output=True)
 
     # check result.conf end times
-    report_times = {("soma_v.h5", "Mosaic"): t[1], ("compartment_i.h5", "Mosaic"): t[1]}
-    check_report_conf(f"checkpoint_{t[1]}", report_times)
+    report_confs = utils.ReportConf.load(f"checkpoint_{t[1]}/report.conf")
+    assert report_confs.reports["soma_v.h5"].end_time == t[1]
+    assert report_confs.reports["compartment_i.h5"].end_time == t[1]
 
     update_sim_conf(t[2], f"output_{t[1]}_{t[2]}")
 
@@ -311,8 +281,9 @@ def test_full_run_vs_save_restore(create_tmp_simulation_config_file):
     subprocess.run(command, check=True, capture_output=True, text=True)
 
     # check result.conf end times
-    report_times = {("soma_v.h5", "Mosaic"): 18, ("compartment_i.h5", "Mosaic"): t[2]}
-    check_report_conf(f"checkpoint_{t[2]}", report_times)
+    report_confs = utils.ReportConf.load(f"checkpoint_{t[2]}/report.conf")
+    assert report_confs.reports["soma_v.h5"].end_time == 18
+    assert report_confs.reports["compartment_i.h5"].end_time == t[2]
 
     # compare celldump states
     full_run_dir = Path(f"output_{t[0]}_{t[2]}")


### PR DESCRIPTION

## Context & Scope
We have more than 1 test now that need to check the file `report.conf`. It is time to have a real loader of this file in `test/utils` so that various tests can use it

## Testing
Already tested in `test_coreneuron_save_restore.py`. If you want I can add a dedicated test in `test_test_utils.py`. I do not know where to plop the `report.conf`... maybe I can create it on the fly...

Let me know if you prefer this option @jamesgking 

