### PR TITLE
add `pytest-of*` to gitignore

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ envlist = format, unit, unit-ngv-mpi, unit-mpi, baseline, integration-e2e, scien
 deps =
     -r tests/requirements.txt
 
-[run]
-patch = subprocess
-
 [testenv:baseline]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
- ignore `pytest-of*`: in this way you can set `export PYTEST_DEBUG_TEMPROOT=$(pwd)` and run the tests in the root folder

