### PR TITLE
`pytest-cov 7.0.0`: improve coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ addopts = [
 markers = ["slow: marks tests as slow"]
 
 [tool.coverage.run]
-patch = ["subprocess"]
+patch = ["subprocess", "_exit"]
 branch = false
 relative_files = true
 source_pkgs = [


### PR DESCRIPTION
## Context
`pytest-cov 7.0.0` added a few breaking changes. Here we are trying to recover the coverage as it was before... or better

based on #386 and:

https://pytest-cov.readthedocs.io/en/latest/changelog.html#id1
https://coverage.readthedocs.io/en/latest/config.html#run-patch
