### PR TITLE
block h5py version since the last wheel fails with mac

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ pytest==7.4
 pytest-forked==1.6
 scipy~=1.10
 pandas
+h5py<=3.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     morphio
 setenv =
     NEURON_INIT_MPI=0
-    PYTHONPATH={toxinidir}:{env:PYTHONPATH}
+    PYTHONPATH={toxinidir}
     COVERAGE_FILE = .coverage.unit
     PYTEST_DEBUG_TEMPROOT={env:PYTEST_DEBUG_TEMPROOT}
 allowlist_externals =
@@ -43,7 +43,7 @@ deps =
     morphio
     -r tests/unit-mpi/requirements.txt
 setenv =
-    PYTHONPATH={toxinidir}:{env:PYTHONPATH}
+    PYTHONPATH={toxinidir}
     NEURON_INIT_MPI=1
     RDMAV_FORK_SAFE=1
     COVERAGE_FILE = .coverage.unit-ngv-mpi
@@ -61,7 +61,7 @@ deps =
     neuron-nightly
     -r tests/unit-mpi/requirements.txt
 setenv =
-    PYTHONPATH={toxinidir}:{env:PYTHONPATH}
+    PYTHONPATH={toxinidir}
     NEURON_INIT_MPI=1
     RDMAV_FORK_SAFE=1
     COVERAGE_FILE = .coverage.unit-mpi


### PR DESCRIPTION
## Context

~~After the update to libsonata report, in macOS CI only (and non CI), h5py started complaining. This is due to the fact that we are picking the wrong hdf5 lib.~~

~~Somehow, this fixes the problem.~~

Thanks to Mike I found out that it was h5py that dropped a new wheel (broken) exactly when I was testing new cmake limit with libsonatareport. I really threw me off the rails. 

## Scope

We limit to the last working version until they fix their wheel

Fix #402
