### PR TITLE
`dump_cellstate` for astrocytes

### DIFF
--- a/neurodamus/utils/dump_cellstate.py
+++ b/neurodamus/utils/dump_cellstate.py
@@ -100,13 +100,18 @@ def dump_netcons(nclist, remove_prefix) -> list:
 def _read_object_attrs(obj, filter_keys=None):
     res = {}
     for x in dir(obj):
-        if (
-            (not filter_keys or x not in filter_keys)
-            and not x.startswith("__")
-            and not callable(getattr(obj, x))
-        ):
+        if (filter_keys and x in filter_keys) or x.startswith("__"):
+            continue
+        try:
             attr = getattr(obj, x)
-            if isinstance(attr, float):
-                attr = round(attr, 14)
-            res[x] = attr
+        except AttributeError:
+            # Skip attributes that cannot be fetched. Nullptrs
+            continue
+        if callable(attr):
+            continue
+        if isinstance(attr, float):
+            attr = round(attr, 14)
+        if type(attr).__name__ == "RangeVar":
+            attr = attr.name()
+        res[x] = attr
     return res

--- a/tests/unit-ngv-mpi/test_dump_cellstate.py
+++ b/tests/unit-ngv-mpi/test_dump_cellstate.py
@@ -1,0 +1,34 @@
+
+import pytest
+
+from neurodamus import Neurodamus
+from tests.conftest import NGV_DIR
+from neurodamus.utils.dump_cellstate import dump_cellstate
+from pathlib import Path
+
+
+
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "src_dir": str(NGV_DIR),
+        "simconfig_file": "simulation_config.json"
+    }
+], indirect=True)
+@pytest.mark.mpi(ranks=1)
+def test_simple_dump(create_tmp_simulation_config_file, mpi_ranks):
+    """
+    Test cell_dumpstate with a neuron and an astrocyte
+    """
+    from neurodamus.core import NeuronWrapper as Nd
+
+    n = Neurodamus(create_tmp_simulation_config_file)
+    astro_ids = list(n.circuits.get_node_manager("AstrocyteA").gid2cell.keys())
+
+    for astro_id in astro_ids:
+        outputfile = Path("cellstate_" + str(astro_id) + ".json")
+        dump_cellstate(n._pc, Nd.cvode, astro_id, outputfile)
+        assert outputfile.exists(), f"Missing dump file: {outputfile}"
+
+
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ setenv =
     NEURON_INIT_MPI=1
     RDMAV_FORK_SAFE=1
     COVERAGE_FILE = .coverage.unit-ngv-mpi
+    PYTEST_DEBUG_TEMPROOT={env:PYTEST_DEBUG_TEMPROOT}
 allowlist_externals =
     {toxinidir}/ci/build_ndcore.sh
     sh


### PR DESCRIPTION
## Context
Fix: #405

## Scope
astrocytes present:
- `RangeVar`
- `cadifus` as possible nullptrs

I tried to expand the capabilities of `_read_object_attrs` to fail/report gracefully without changing its behavior otherwise. 

## Testing
- the old tests keep working
- New small test in `tests/ngv-unit-mpi/test_dump_cellstate
