### PR TITLE
remove `check_signal_peaks` as it is superfluous

### DIFF
--- a/tests/unit-mpi/test_loadbalance.py
+++ b/tests/unit-mpi/test_loadbalance.py
@@ -7,6 +7,10 @@ import tempfile
 
 from neurodamus import Neurodamus
 
+import numpy as np
+from scipy.signal import find_peaks
+
+
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 size = comm.Get_size()
@@ -110,4 +114,5 @@ def test_load_balance_simulation(request, create_tmp_simulation_config_file, lb_
         npt.assert_allclose(timestamps_ref, timestamps)
 
         # Check voltage variation in RingB population cell
-        utils.check_signal_peaks(voltage_vec, voltage_peaks_ref)
+        peaks_pos = find_peaks(voltage_vec, prominence=1)[0]
+        np.testing.assert_allclose(peaks_pos, voltage_peaks_ref)

--- a/tests/unit/test_connection_overrides.py
+++ b/tests/unit/test_connection_overrides.py
@@ -5,8 +5,10 @@ https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html#connect
 """
 
 
-import numpy as np
+
 import pytest
+import numpy as np
+from scipy.signal import find_peaks
 
 from tests import utils
 
@@ -276,8 +278,21 @@ def test_spont_minis_simple(create_tmp_simulation_config_file):
     Ndc.finitialize()  # reinit for the recordings to be registered
     nd.run()
 
-    utils.check_signal_peaks(voltage_trace, [15,  58, 167, 272, 388], threshold=0.5)
+    peaks_pos = find_peaks(voltage_trace, prominence=0.3)[0]
+    np.testing.assert_allclose(peaks_pos, [ 15,  58, 125, 167, 272, 306, 388])
 
+    ## debug: print the voltage_trage and the detected peaks
+    # import matplotlib.pyplot as plt
+    # trace = np.array(voltage_trace)
+    # plt.figure()
+    # plt.plot(trace, label="Voltage trace")
+    # plt.scatter(peaks_pos, trace[peaks_pos], marker="x", s=80, label="Peaks")
+    # plt.grid(True)
+    # plt.xlabel("Time index")
+    # plt.ylabel("Voltage (mV)")
+    # plt.title("Spontaneous Minis Trace with Peaks")
+    # plt.legend()
+    # plt.show()
 
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
     {

--- a/tests/unit/test_current_injection.py
+++ b/tests/unit/test_current_injection.py
@@ -1,5 +1,6 @@
 import pytest
-from tests import utils
+import numpy as np
+from scipy.signal import find_peaks
 
 
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
@@ -38,4 +39,5 @@ def test_current_injection(create_tmp_simulation_config_file):
     Nd.finitialize()
     nd.run()
 
-    utils.check_signal_peaks(voltage_vec, [92, 291])
+    peaks_pos = find_peaks(voltage_vec, prominence=1)[0]
+    np.testing.assert_allclose(peaks_pos, [92, 291])

--- a/tests/unit/test_gapjunctions.py
+++ b/tests/unit/test_gapjunctions.py
@@ -5,14 +5,16 @@ import numpy.testing as npt
 import pytest
 import pickle
 
-from tests.utils import check_signal_peaks
-
 from ..conftest import RINGTEST_DIR
 from neurodamus import Neurodamus
 from neurodamus.connection_manager import SynapseRuleManager
 from neurodamus.core.configuration import SimConfig
 from neurodamus.gap_junction import GapJunctionManager
 from pathlib import Path
+
+import numpy as np
+from scipy.signal import find_peaks
+
 
 
 @pytest.mark.parametrize(
@@ -81,7 +83,9 @@ def test_gapjunctions_default(create_tmp_simulation_config_file):
     tgtvar_vec.record(tgt_cellref.soma[0](0.5)._ref_v)
     h.finitialize()  # reinit for the recordings to be registered
     nd.run()
-    check_signal_peaks(tgtvar_vec, [52, 57, 252, 257, 452, 457])
+
+    peaks_pos = find_peaks(tgtvar_vec, prominence=1)[0]
+    np.testing.assert_allclose(peaks_pos, [52, 57, 252, 257, 452, 457])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_replay_manager.py
+++ b/tests/unit/test_replay_manager.py
@@ -13,6 +13,9 @@ from neurodamus.connection import NetConType
 from neurodamus.core.configuration import ConfigurationError, Feature, SimConfig
 from neurodamus.replay import MissingSpikesPopulationError, SpikeManager
 
+import numpy as np
+from scipy.signal import find_peaks
+
 INPUT_SPIKES_FILE = str(RINGTEST_DIR / "input_spikes.h5")
 
 
@@ -204,7 +207,8 @@ def test_replay_stim_generated_run(create_tmp_simulation_config_file):
     Nd.finitialize()
     nd.run()
 
-    utils.check_signal_peaks(voltage_vec, [42, 84], 0.5)
+    peaks_pos = find_peaks(voltage_vec, prominence=0.5)[0]
+    np.testing.assert_allclose(peaks_pos, [42, 84])
 
 
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [
@@ -257,4 +261,9 @@ def test_replay_virtual_population(create_tmp_simulation_config_file):
     Nd.finitialize()
     nd.run()
 
-    utils.check_signal_peaks(voltage_vec, [42, 84], 0.5)
+    peaks_pos = find_peaks(voltage_vec, prominence=0.5)[0]
+    np.testing.assert_allclose(peaks_pos, [42, 84])
+
+
+
+    

--- a/tests/unit/test_ringcells_reports.py
+++ b/tests/unit/test_ringcells_reports.py
@@ -7,8 +7,12 @@ from neurodamus.core.configuration import SimConfig
 from neurodamus.core.coreneuron_configuration import CoreConfig
 from neurodamus.utils.pyutils import CumulativeError
 from neurodamus.node import Node
-from tests.utils import (check_signal_peaks, read_ascii_report,
+from tests.utils import (read_ascii_report,
                          record_compartment_reports, write_ascii_reports)
+
+import numpy as np
+from scipy.signal import find_peaks
+
 
 
 @pytest.mark.parametrize(
@@ -319,7 +323,8 @@ def test_neuron_compartment_ASCIIReport(create_tmp_simulation_config_file):
     assert len(data) == 2500  # 500 time steps * 5 soma sections
     # check soma signal peak for cell 1001 as in test_current_injection.py
     cell_voltage_vec = [vec[3] for vec in data if vec[0] == 1001]
-    check_signal_peaks(cell_voltage_vec, [92, 291])
+    peaks_pos = find_peaks(cell_voltage_vec, prominence=1)[0]
+    np.testing.assert_allclose(peaks_pos, [92, 291])
 
     compartment_i_report = Path(n._run_conf["OutputRoot"]) / ("compartment_i.txt")
     assert compartment_i_report.exists()
@@ -327,8 +332,8 @@ def test_neuron_compartment_ASCIIReport(create_tmp_simulation_config_file):
     assert len(data) == 1025  # 45 time steps * 5*5 compartments
     cell_current_vec = [vec[3] for vec in data if vec[0] == 1001]
 
-    check_signal_peaks(cell_current_vec, [9,  29,  50,  70, 110, 132, 152, 173, 193],
-                       threshold=0.05)
+    peaks_pos = find_peaks(cell_current_vec, prominence=0.05)[0]
+    np.testing.assert_allclose(peaks_pos, [9,  29,  50,  70, 110, 132, 152, 173, 193])
     
     compartment_pas_report = Path(n._run_conf["OutputRoot"]) / ("compartment_pas.txt")
     assert compartment_pas_report.exists()

--- a/tests/unit/test_test_utils.py
+++ b/tests/unit/test_test_utils.py
@@ -276,18 +276,6 @@ def test_merge_simulation_configs(create_tmp_simulation_config_file):
         assert len(config_data["run"]) == 3
 
 
-def test_check_signal_peaks():
-    x = np.array([-60., -59., -20., -30., -50., -40., -55., -59., -10., -15., -30., -49., -60.])
-    ref_pos = [2, 5, 8]
-    utils.check_signal_peaks(x, ref_pos)
-
-    x_ramp = x + np.arange(len(x)) * 2
-    utils.check_signal_peaks(x_ramp, ref_pos)
-
-    x_ramp = x + np.arange(len(x)) * -2
-    utils.check_signal_peaks(x_ramp, ref_pos)
-
-
 def test_compare_outdat_files_identical(tmp_path):
     content = """5.1 1\n5.1 2\n5.1 3\n25.1 1\n25.1 2\n25.1 3"""
     file1, file2 = tmp_path / 'out1.dat', tmp_path / 'out2.dat'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -302,27 +302,6 @@ def check_synapse(syn, edges, selection, **kwargs):
     if "NMDA_ratio" in kwargs and hasattr(syn, "NMDA_ratio"):
         assert np.isclose(syn.NMDA_ratio, kwargs["NMDA_ratio"])
 
-
-def check_signal_peaks(x, ref_peaks_pos, threshold=1, tolerance=0):
-    """
-    Check the given signal peaks comparing with the given
-    reference
-
-    Args:
-        x: given signal, typically voltage.
-        ref_peaks_pos: the position of the signal peaks
-        taken as reference.
-        threshold: peak detection threshold measured with
-        respect of the surrounding baseline of the signal
-        tolerance: peak detection tolerance window per peak
-
-    Raises:
-        AssertionError: If any of the reference peak
-        positions doesn't match with the obtained peaks
-    """
-    peaks_pos = find_peaks(x, prominence=threshold)[0]
-    np.testing.assert_allclose(peaks_pos, ref_peaks_pos, atol=tolerance)
-
 def record_compartment_reports(target_manager: TargetManager, nd_t=0):
     """For compartment report, retrieve segments, and record the pointer of reporting variable
     More details in NEURON Vector.record()


### PR DESCRIPTION
## Context
Fix: #403

## Scope

- We remove `check_signal_peaks` as it was superfluous
- change prominence in test_connection_overrides to catch all the peaks

## Testing

It was already tested
