### PR TITLE
add test to check that direct mode produces the same files as file mode

### DIFF
--- a/tests/integration-e2e/test_reports.py
+++ b/tests/integration-e2e/test_reports.py
@@ -465,5 +465,3 @@ def test_reports_cell_permute(create_tmp_simulation_config_file):
 
         assert r.allclose(r_reference, **(loose_tols if ref_file.name in loose_tol_files else {})), f"The reports differ:\n{file}\n{ref_file}"
 
-
-


### PR DESCRIPTION
## Context
direct mode was never tested properly, with integration tests. It was just tested in the unit tests, with a fake libsonatareport. 

## Scope
Test that coreneuron direct mode returns the same results as file mode. They should be the same but it is nice to check