### PR TITLE
Remove LIBSONATA_ZERO_BASED_GIDS as of libsonatareport-2.0.0

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -234,7 +234,6 @@ jobs:
         export PYTHONPATH=$(pwd)/nrn/build/install/lib/python:$PYTHONPATH
         export HOC_LIBRARY_PATH=$NEURODAMUS_NEOCORTEX_ROOT/share/neurodamus_neocortex/hoc
         export NEURODAMUS_PYTHON=$(pwd)/neurodamus/data
-        export LIBSONATA_ZERO_BASED_GIDS=1
         if [[ "${{matrix.os}}" == *"macOS"* ]]; then
           export CORENEURONLIB=$NEURODAMUS_NEOCORTEX_ROOT/lib/libcorenrnmech.dylib
           export NRNMECH_LIB_PATH=$NEURODAMUS_NEOCORTEX_ROOT/lib/libnrnmech.dylib

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,6 @@ setenv =
     PYTHONPATH={toxinidir}:{env:PYTHONPATH}
     HOC_LIBRARY_PATH={toxinidir}/neurodamus/data/hoc:{env:HOC_LIBRARY_PATH}
     NEURON_INIT_MPI=1
-    LIBSONATA_ZERO_BASED_GIDS=1
 commands =
     python -c "import os; print(os.environ.get('HOC_LIBRARY_PATH', ''))"
     pytest -s -x --forked --durations=5 --durations-min=15 {posargs:tests/integration-e2e}
@@ -93,7 +92,6 @@ setenv =
     PYTHONPATH={toxinidir}:{env:PYTHONPATH}
     HOC_LIBRARY_PATH={toxinidir}/neurodamus/data/hoc:{env:HOC_LIBRARY_PATH}
     NEURON_INIT_MPI=1
-    LIBSONATA_ZERO_BASED_GIDS=1
 commands =
     python -c "import os; print(os.environ.get('HOC_LIBRARY_PATH', ''))"
     pytest -s -x --forked --durations=5 --durations-min=15 {posargs:tests/scientific}


### PR DESCRIPTION
`libsonatareport` is 0-based from 2.0.0 so `LIBSONATA_ZERO_BASED_GIDS` is no more needed in simulation.