### PR TITLE
Remove using `:` as a way to split sub-parts of Edges, Targets, etc

### DIFF
--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -486,7 +486,6 @@ def _projection_params(config: _SimConfig):
     required_fields = ("Path",)
     for name, proj in config.projections.items():
         _check_params("Projection " + name, proj, required_fields, (), ())
-        _validate_file_extension(proj.get("Path"))
 
 
 @SimConfig.validator
@@ -580,8 +579,6 @@ def make_circuit_config(config_dict, req_morphology=True):
     elif config_dict.get("nrnPath") == "<NONE>":
         config_dict["nrnPath"] = False
     _validate_circuit_morphology(config_dict, req_morphology)
-    _validate_file_extension(config_dict.get("CellLibraryFile"))
-    _validate_file_extension(config_dict.get("nrnPath"))
     return CircuitConfig(config_dict)
 
 
@@ -602,16 +599,6 @@ def _validate_circuit_morphology(config_dict, required=True):
         config_dict["MorphologyPath"] = morph_path
     assert morph_type in {"asc", "swc", "h5", "hoc"}, "Invalid MorphologyType"
     log_verbose(" > MorphologyType = %s, src: %s", morph_type, morph_path)
-
-
-def _validate_file_extension(path):
-    if not path:
-        return
-    filepath = path.split(":")[0]  # for sonata, remove the edge_pop name appended to the file path
-    if filepath.endswith(".sonata"):
-        raise ConfigurationError(
-            "*.sonata files are no longer supported, please rename them to *.h5"
-        )
 
 
 @SimConfig.validator

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -8,6 +8,8 @@ from enum import Enum
 
 import libsonata
 
+from neurodamus.types import QualifiedEdgePopulation
+
 
 class ConnectionTypes(str, Enum):
     Synaptic = "Synaptic"
@@ -145,6 +147,7 @@ class SonataConfig:
             all connectivity as projections, under certain circuitry, like NGV, order matters and
             therefore we keep inner connectivity to ensure they are created in the same order,
             respecting engine precedence
+
             For edges to be considered inner connectivity they must be named "default"
             """
             for edge_pop_name in self._stable_edge_populations:
@@ -157,7 +160,9 @@ class SonataConfig:
                     and edge_properties.type == "chemical"
                     and edge_pop_name == "default"
                 ):
-                    return edge_properties.elements_path + ":" + edge_pop_name
+                    return QualifiedEdgePopulation(
+                        path=edge_properties.elements_path, name=edge_pop_name
+                    )
             return False
 
         def make_circuit(node_pop_name, node_prop):
@@ -223,7 +228,7 @@ class SonataConfig:
                     edges_file = os.path.join(os.path.dirname(self._sim_conf.network), edges_file)
 
                 # skip inner connectivity populations
-                edge_pop_path = edges_file + ":" + edge_pop_name
+                edge_pop_path = QualifiedEdgePopulation(path=edges_file, name=edge_pop_name)
                 if edge_pop_path in internal_edge_pops:
                     continue
 

--- a/neurodamus/ngv.py
+++ b/neurodamus/ngv.py
@@ -21,6 +21,7 @@ from .io.synapse_reader import SonataReader, SynapseParameters
 from .metype import BaseCell
 from .morphio_wrapper import MorphIOWrapper
 from .utils.pyutils import append_recarray
+from neurodamus.types import QualifiedEdgePopulation
 
 
 class Astrocyte(BaseCell):
@@ -394,15 +395,11 @@ class GlioVascularManager(ConnectionManagerBase):
         self._astro_ids = self._cell_manager.local_nodes.gids(raw_gids=True)
         self._gid_offset = self._cell_manager.local_nodes.offset
 
-    def open_edge_location(self, sonata_source, circuit_conf, **__):
-        logging.info("GlioVascular sonata file %s", sonata_source)
-        # sonata files can have multiple populations. In building we only use one
-        # per file, hence this two lines below to access the first and only pop in
-        # the file
-        edge_file, *pop = sonata_source.split(":")
-        storage = libsonata.EdgeStorage(edge_file)
-        pop_name = pop[0] if pop else next(iter(storage.population_names))
-        self._gliovascular = storage.open_population(pop_name)
+    def open_edge_location(self, edge_location: QualifiedEdgePopulation, circuit_conf, **__):
+        logging.info("GlioVascular sonata file %s", edge_location)
+        self._gliovascular = libsonata.EdgeStorage(edge_location.path).open_population(
+            edge_location.name
+        )
 
         storage = libsonata.NodeStorage(circuit_conf["VasculaturePath"])
         pop_name = next(iter(storage.population_names))

--- a/neurodamus/types.py
+++ b/neurodamus/types.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class QualifiedNodePopulation:
+    path: Path
+    name: str
+
+
+@dataclass(frozen=True)
+class QualifiedEdgePopulation:
+    path: Path
+    name: str
+
+
+NRNPath = QualifiedEdgePopulation | bool
+
+# CellLibraryFile

--- a/tests/scientific/test_synapses.py
+++ b/tests/scientific/test_synapses.py
@@ -66,9 +66,8 @@ def test_synapses_params():
     plast_params = ["volume_CR", "rho0_GB", "Use_d_TM", "Use_p_TM",
                     "gmax_d_AMPA", "gmax_p_AMPA", "theta_d", "theta_p", "gmax_NMDA"]
 
-    edges_file, edge_pop = n._sonata_circuits[pop1].nrnPath.split(":")
-    storage = EdgeStorage(edges_file)
-    edge_pop = storage.open_population(edge_pop)
+    edge_location = n._sonata_circuits[pop1].nrnPath
+    edge_pop = EdgeStorage(edge_location.path).open_population(edge_location.name)
     sel1 = edge_pop.connecting_edges(pre_L5_BC, post_L5_PC)
     sel2 = edge_pop.connecting_edges(pre_L5_PC, post_L5_PC)
     df = get_edge_properties(edge_pop, sel1, properties)

--- a/tests/unit/test_circuitconfig.py
+++ b/tests/unit/test_circuitconfig.py
@@ -3,6 +3,7 @@ Unit tests for the CircuitConfig class (internal data structure),
 and the parsing from a circuit info
 which is usually translated from a SONATA config file done in sonata_config.py
 """
+from neurodamus.types import QualifiedEdgePopulation
 
 import pytest
 
@@ -35,7 +36,8 @@ def test_ringtest_circuitconf(create_tmp_simulation_config_file):
         "MorphologyPath": str(RINGTEST_DIR / "morphologies/asc"),
         "MorphologyType": "asc",
         "PopulationType": "biophysical",
-        "nrnPath": str(RINGTEST_DIR / "local_edges_A.h5:RingA__RingA__chemical"),
+        "nrnPath": QualifiedEdgePopulation(path=str(RINGTEST_DIR / "local_edges_A.h5"),
+                                           name="RingA__RingA__chemical")
     }
 
 
@@ -93,18 +95,3 @@ def test_default_morphology_type():
     circuit_conf = make_circuit_config(circuit_dict, req_morphology=False)
     assert circuit_conf.MorphologyType == "asc"
     assert circuit_conf.MorphologyPath == "dummy/ascii"
-
-
-def test_validation_file_extension():
-    """
-    Test the validation of file extension for CellLibraryFile and nrnPath
-    """
-    for circuit_dict in [
-        {"CellLibraryFile": "nodes.sonata", "MorphologyPath": "dummy"},
-        {"CellLibraryFile": "nodes.h5", "MorphologyPath": "dummy", "nrnPath": "edges.sonata"},
-    ]:
-        with pytest.raises(
-            ConfigurationError,
-            match=r"\*.sonata files are no longer supported, please rename them to \*.h5",
-        ):
-            make_circuit_config(circuit_dict)

--- a/tests/unit/test_compartment_set_stimulus.py
+++ b/tests/unit/test_compartment_set_stimulus.py
@@ -25,7 +25,7 @@ from collections import Counter
                         "frequency": 50,
                         "delay": 0,
                         "duration": 50,
-                        "compartment_set":"csA",
+                        "compartment_set": "csA",
                     },
                 },
             },
@@ -57,5 +57,3 @@ def test_compartment_set_input(create_tmp_simulation_config_file):
                     if "IClamp" in pp.hname() and seg.x > 0 and seg.x < 1
                 )
                 assert count == clamps.get((cell.gid, section_id), 0)
-
-

--- a/tests/unit/test_loadbalance.py
+++ b/tests/unit/test_loadbalance.py
@@ -67,6 +67,7 @@ def test_loadbal_subtarget(target_manager, caplog):
         assert "Attempt reusing cx files from other targets..." in caplog.records[-2].message
         assert "Target VerySmall is a subset of the target RingA_All." in caplog.records[-1].message
 
+
 @pytest.fixture
 def circuit_conf_bigcell():
     """Test nodes file contains 1 big cell with 10 dendrites + 2 small cells with 2 dendrites"""
@@ -81,6 +82,7 @@ def circuit_conf_bigcell():
         CircuitTarget="All",
     )
 
+
 @pytest.fixture
 def circuit_conf():
     """Test nodes file contains 3 small cells with 2 dendrites each"""
@@ -94,6 +96,7 @@ def circuit_conf():
         nrnPath=False,  # no connectivity
         CircuitTarget="All",
     )
+
 
 def test_load_balance_integrated(target_manager, circuit_conf):
     """Comprehensive test using real cells and deriving cx for a sub-target"""
@@ -232,6 +235,7 @@ def test_WholeCell(target_manager, circuit_conf, capsys):
     content = Path(cpu_assign_filename).open().read()
     assert content == "msgid 10000000\nnhost 2\n0 2  0 0 0  2 2 0\n1 1  1 1 0\n"
 
+
 def test_WholeCell_bigcell(target_manager, circuit_conf_bigcell, capsys):
     """Ensure given the right files are in the lbal dir, the correct situation is detected"""
     from neurodamus.cell_distributor import CellDistributor, LoadBalance, TargetSpec
@@ -250,8 +254,9 @@ def test_WholeCell_bigcell(target_manager, circuit_conf_bigcell, capsys):
 
     # Check the cpu assign file
     cpu_assign_filename = next(Path(".").glob(str(base_dir / pattern / "cx_RingA_All#.2.dat")))
-    content = Path(cpu_assign_filename).open().read()
-    assert content == "msgid 10000000\nnhost 2\n0 1  0 0 0\n1 2  1 1 0  2 2 0\n"
+    with Path(cpu_assign_filename).open(encoding="utf-8") as fd:
+        assert fd.read() == "msgid 10000000\nnhost 2\n0 1  0 0 0\n1 2  1 1 0  2 2 0\n"
+
 
 class MockedTargetManager:
     """
@@ -275,4 +280,3 @@ class MockedTargetManager:
 
     def register_local_nodes(*_):
         pass
-

--- a/tests/unit/test_test_utils.py
+++ b/tests/unit/test_test_utils.py
@@ -20,9 +20,8 @@ def get_edges_data(create_tmp_simulation_config_file):
     from neurodamus.core import NeuronWrapper as Nd
 
     n = Neurodamus(create_tmp_simulation_config_file, disable_reports=True)
-    edges_file, edge_pop = SimConfig.sonata_circuits["RingB"].nrnPath.split(":")
-    edge_storage = EdgeStorage(edges_file)
-    edges = edge_storage.open_population(edge_pop)
+    edge_location = SimConfig.sonata_circuits["RingB"].nrnPath
+    edges = EdgeStorage(edge_location.path).open_population(edge_location.name)
     sgid, tgid = 0, 1
     cell = n._pc.gid2cell(tgid)
     selection = edges.afferent_edges(tgid)
@@ -85,7 +84,7 @@ def test_check_netcons(create_tmp_simulation_config_file):
     }
 ], indirect=True)
 def test_check_synapse(create_tmp_simulation_config_file):
-    sgid, _, _, edges, selection, nclist = get_edges_data(create_tmp_simulation_config_file)
+    _, _, _, edges, selection, nclist = get_edges_data(create_tmp_simulation_config_file)
 
     # base
     utils.check_synapse(next(iter(nclist)).syn(), edges, selection)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,14 +123,9 @@ def get_edge_data(nd, src_pop: str, src_rawgid: int, tgt_pop: str, tgt_rawgid: i
     src_pop_offset = nd.circuits.get_node_manager(src_pop).local_nodes.offset
     src_gid = src_rawgid + src_pop_offset
 
-    if src_pop == tgt_pop:
-        edges_file, edge_pop = \
-            nd.circuits.get_edge_managers(tgt_pop, tgt_pop)[0].circuit_conf.nrnPath.split(":")
-    else:
-        edges_file, edge_pop = \
-            nd.circuits.get_edge_managers(src_pop, tgt_pop)[0].circuit_conf["Path"].split(":")
-    edge_storage = EdgeStorage(edges_file)
-    edges = edge_storage.open_population(edge_pop)
+    circuit_conf = nd.circuits.get_edge_managers(src_pop, tgt_pop)[0].circuit_conf
+    edge_location = circuit_conf.nrnPath if src_pop == tgt_pop else circuit_conf["Path"]
+    edges = EdgeStorage(edge_location.path).open_population(edge_location.name)
     selection = edges.afferent_edges(tgt_rawgid)
     return src_gid, tgt_gid, edges, selection
 


### PR DESCRIPTION
Switch away from ":" style string usage for EdgePopulation

* this was a carry over from the pre-sonata days, however, all
  connectivity should be qualified with both a file and a population now