### PR TITLE
Fix `IonChannelSeed` from not getting set

### DIFF
--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -58,6 +58,10 @@ class SonataConfig:
             "spike_threshold": "SpikeThreshold",
             "integration_method": "SecondOrder",
             "electrodes_file": "LFPWeightsPath",
+            "stimulus_seed": "StimulusSeed",
+            "ionchannel_seed": "IonChannelSeed",
+            "minis_seed": "MinisSeed",
+            "synapse_seed": "SynapseSeed",
         }
         parsed_run = self._translate_dict(item_translation, self._sim_conf.run)
 

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -21,6 +21,12 @@ def test_parse_base():
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
+            "run": {
+                "stimulus_seed": 42,
+                "ionchannel_seed": 43,
+                "minis_seed": 44,
+                "synapse_seed": 45,
+            },
             "conditions": {
                 "extracellular_calcium": 1.2,
             }
@@ -31,6 +37,10 @@ def test_parse_run(create_tmp_simulation_config_file):
     SimConfig.init(create_tmp_simulation_config_file, {})
     # RNGSettings in hoc correctly initialized from Sonata
     assert SimConfig.rng_info.getGlobalSeed() == 1122
+    assert SimConfig.rng_info.getStimulusSeed() == 42
+    assert SimConfig.rng_info.getIonChannelSeed() == 43
+    assert SimConfig.rng_info.getMinisSeed() == 44
+    assert SimConfig.rng_info.getSynapseSeed() == 45
 
     expected_conf = {
         "PopulationName": None,


### PR DESCRIPTION
* Previously, `ionchannel_seed `was getting translated as `IonchannelSeed` but `RNGSettings.hoc` was looking for `IonChannelSeed` (note capitalization difference)
* made all translations explicit
* added test