### PR TITLE
`SonataConfig.Conditions` rework

### DIFF
--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -86,37 +86,8 @@ class SonataConfig:
         return parsed_run
 
     @property
-    def Conditions(self):
-        item_translation = {"randomize_gaba_rise_time": "randomize_Gaba_risetime"}
-        conditions = {}
-        blacklist = (
-            "Celsius",
-            "VInit",
-            "ExtracellularCalcium",
-            "ListModificationNames",
-            "SpikeLocation",
-        )
-        for key, value in self._translate_dict(item_translation, self._sim_conf.conditions).items():
-            if key in blacklist:
-                continue
-            if key == "Mechanisms":
-                for suffix, dict_var in value.items():
-                    for name, val in dict_var.items():
-                        conditions[name + "_" + suffix] = val
-            else:
-                conditions[key] = value
-
-        conditions["randomize_Gaba_risetime"] = str(conditions["randomize_Gaba_risetime"])
-
-        print("AAA")
-        bb = self._translate_dict(item_translation, self._sim_conf.conditions)
-        print(bb)
-        print()
-        print(conditions)
-        # if 'Mechanisms' in bb:
-        #     if len(bb['Mechanisms']):
-
-        return {"Conditions": conditions}
+    def parsedConditions(self):
+        return self._sim_conf.conditions
 
     def _extract_circuits_info(self) -> dict:  # noqa: C901
         """Extract the circuits information from confile file with libsonata.CircuitConfig parser,
@@ -339,8 +310,6 @@ class SonataConfig:
 
     @property
     def parsedModifications(self):
-        print(self._sim_conf.conditions.modifications())
-
         item_translation = {"node_set": "Target"}
         result = {}
         for modification in self._sim_conf.conditions.modifications():

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -100,14 +100,10 @@ def test_extracellular_calcium_warning(create_tmp_simulation_config_file, caplog
 def test_parse_conditions(create_tmp_simulation_config_file):
     SimConfig.init(create_tmp_simulation_config_file, {})
 
-    expected_conditions = {
-        "init_depleted_ProbAMPANMDA_EMS": False,
-        "minis_single_vesicle_ProbAMPANMDA_EMS": True,
-        "randomize_Gaba_risetime": "False"
-    }
-
-    utils.check_is_subset(next(iter(SimConfig._simulation_config.Conditions.values())),
-                          expected_conditions)
+    cond = SimConfig._simulation_config.parsedConditions
+    assert cond.randomize_gaba_rise_time == False
+    assert cond.mechanisms["ProbAMPANMDA_EMS"]["init_depleted"] == False
+    assert cond.mechanisms["ProbAMPANMDA_EMS"]["minis_single_vesicle"] == True
     assert SimConfig.run_conf["SpikeLocation"] == "AIS"
 
 


### PR DESCRIPTION
## Context
Fix #451 

## Scope
- remove `_condition_checks`. It was used for a value that is never set and a value that is always a bool from libsonata
- use libsonata connections. We just need to read. No need of conversions etc. I left the `parsedConnections` (did we forget a parsed?) to link with the past. It may be removed

## Testing
already tested
