### PR TITLE
Fix CI tests: pandas no longer supports groupby axis=1  

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -458,7 +458,7 @@ class ReportReader:
 
         for name, (nodes, df) in self.populations.items():
             if isinstance(df.columns, pd.MultiIndex) and df.columns.nlevels > 1:
-                new_df = df.groupby(level=0, axis=1).sum()
+                new_df = df.T.groupby(level=0).sum().T
                 # force 2-level MultiIndex with second level zeros
                 new_df.columns = pd.MultiIndex.from_arrays([
                     new_df.columns,


### PR DESCRIPTION
As of pandas 3.0.0, DataFrame groupby always operates along axis 0 (rows). To split by columns, we need first do a transpose. `df.groupby(..., axis=1)` -> `df.T.groupby(..)`
https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html#group-by-split-apply-combine