### PR TITLE
Dockerfile: set neuron default tag 9.0.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-c"]
 
 ARG LIBSONATA_TAG=master
 ARG LIBSONATAREPORT_TAG=master
-ARG NEURON_TAG=master
+ARG NEURON_TAG=9.0.1
 ARG NEURON_COMMIT_ID
 ARG WORKDIR=/opt/software
 ARG INSTALL_DIR=/opt/software/install


### PR DESCRIPTION
Neurodamus requires NEURON >= 9.0a-1485-g0d990513b because the layout of `report.conf` changed in this commit. Therefore in the docker image file, we set the neuron default tag to the current latest 9.0.1 in order to pass this change in the docker container.