### PR TITLE
In some rare cases metadata can return None

### DIFF
--- a/neurodamus/_metadata.py
+++ b/neurodamus/_metadata.py
@@ -2,8 +2,10 @@ import importlib.metadata
 
 try:
     __version__ = importlib.metadata.version("neurodamus")
+    if __version__ is None:
+        __version__ = "devel"
 except importlib.metadata.PackageNotFoundError:
     __version__ = "devel"
 
-__author__ = "Fernando Pereira <fernando.pereira@epfl.ch>"
-__copyright__ = "2018 Blue Brain Project, EPFL"
+__author__ = "Blue Brain Project/EPFL"
+__copyright__ = "Copyright 2005-2023 Blue Brain Project/EPFL"


### PR DESCRIPTION
## Context

Fix: #494 

We should avoid it otherwise coopt does not exit correctly in case of --version and code exec continues

## Scope

updated `_metadata.py`

