### PR TITLE
Skip LFP electrodes file loading when reports are disabled

### DIFF
--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -578,7 +578,7 @@ class Node:
             )
 
         lfp_weights_file = self._run_conf.lfp_weights_path
-        if lfp_weights_file:
+        if lfp_weights_file and self._run_conf.enable_reports:
             if SimConfig.use_coreneuron:
                 lfp_manager = self._circuits.global_manager._lfp_manager
                 cell_managers = self._circuits.global_manager._cell_managers

--- a/tests/unit/test_lfp.py
+++ b/tests/unit/test_lfp.py
@@ -165,3 +165,22 @@ def test_lfp_reports(create_tmp_simulation_config_file):
     assert rep_config.file_name == str(Path(CoreConfig.output_root) / (rep_name + ".h5"))
 
     nd.run()
+
+
+@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+    {
+        "simconfig_fixture": "ringtest_baseconfig",
+        "extra_config": {
+            "target_simulator": "CORENEURON",
+            "run": {
+                "electrodes_file": "/nonexistent/path/lfp_file.h5"
+            },
+        }
+    },
+], indirect=True)
+def test_missing_electrodes_file(create_tmp_simulation_config_file):
+    """Test that a missing electrodes_file does not crash when reports are disabled."""
+    from neurodamus import Neurodamus
+
+    nd = Neurodamus(create_tmp_simulation_config_file, disable_reports=True)
+    nd.run()


### PR DESCRIPTION
## Context

Fix: #501 

## Scope

The electrodes file is only needed for LFP reporting. When reports are disabled, there is no reason to load it, and a missing file should not cause a failure.

## Testing

Add a test to verify this behavior