### PR TITLE
Pin NEURON to tag 9.0.1 instead of commit hash

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -33,7 +33,7 @@ on:
         required: false
 
 env:
-  NEURON_COMMIT_ID: '0d990513b'
+  NEURON_COMMIT_ID: '9.0.1'
   RDMAV_FORK_SAFE: '1'
 
 jobs:


### PR DESCRIPTION
## Context

@jplanasc suggested to pin neuron to 9.0.1 not the current commit