### PR TITLE
Build neurodamus with openMPI in the integration CI workflow

### DIFF
--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -99,7 +99,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install -y mpich libmpich-dev libhdf5-mpich-dev hdf5-tools flex libfl-dev bison ninja-build
+        sudo apt-get install -y libopenmpi-dev openmpi-bin libhdf5-openmpi-dev hdf5-tools flex libfl-dev bison ninja-build
 
     - name: Install macOS homebrew packages
       if: startsWith(matrix.os, 'macOS')
@@ -117,7 +117,7 @@ jobs:
         cache-name: cache-venv
       with:
         path: venv
-        key: ${{ matrix.os }}-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ steps.pyver.outputs.version }}
+        key: ${{ matrix.os }}-openmpi-libsonata-${{ env.LIBSONATA_BRANCH }}-py${{ steps.pyver.outputs.version }}
 
     - name: Upgrade pip and install base Python packages
       if: steps.cache-venv.outputs.cache-hit != 'true'
@@ -142,11 +142,13 @@ jobs:
         cache-name: cache-libsonatareport
       with:
         path: libsonatareport
-        key: ${{ matrix.os }}-libsonatareport-${{ env.LIBSONATA_REPORT_BRANCH }}-py${{ steps.pyver.outputs.version }}
+        key: ${{ matrix.os }}-openmpi-libsonatareport-${{ env.LIBSONATA_REPORT_BRANCH }}-py${{ steps.pyver.outputs.version }}
 
     - name: Install libsonatareport
       if: steps.cache-libsonatareport.outputs.cache-hit != 'true'
       run: |
+        export CC=$(which mpicc)
+        export CXX=$(which mpic++)
         git clone --branch="${{ env.LIBSONATA_REPORT_BRANCH}}" https://github.com/openbraininstitute/libsonatareport.git --recursive --depth=1
         cd libsonatareport
         mkdir build && cd build
@@ -161,7 +163,7 @@ jobs:
         cache-name: cache-neuron
       with:
         path: nrn
-        key: ${{ matrix.os }}-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}-py${{ steps.pyver.outputs.version }}
+        key: ${{ matrix.os }}-openmpi-neuron-${{ env.NEURON_BRANCH }}-${{ env.NEURON_COMMIT_ID }}-py${{ steps.pyver.outputs.version }}
 
 
     - name: Install NEURON
@@ -201,8 +203,8 @@ jobs:
           export HDF5_INCLUDEDIR=$(brew --prefix hdf5-mpi)/include
           export HDF5_LIBDIR=$(brew --prefix hdf5-mpi)/lib
         else
-          export HDF5_INCLUDEDIR=/usr/include/hdf5/mpich
-          export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/mpich
+          export HDF5_INCLUDEDIR=/usr/include/hdf5/openmpi
+          export HDF5_LIBDIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
         fi
         # Upgrade setuptools again, to avoid build error from `project.license`
         # Neuron installed older setuptools but it doesn't work for h5py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get --yes -qq update \
                       cmake \
                       wget \
                       vim \
-                      mpich libmpich-dev libhdf5-mpich-dev hdf5-tools \
+                      libopenmpi-dev openmpi-bin libhdf5-openmpi-dev hdf5-tools \
                       flex libfl-dev bison ninja-build libreadline-dev \
  && apt-get --yes -qq clean \
  && rm -rf /var/lib/apt/lists/* \
@@ -43,6 +43,8 @@ RUN source $USR_VENV/bin/activate \
 # Install libsonatareport
 RUN mkdir -p $WORKDIR \
  && cd $WORKDIR \
+ && export CC=$(which mpicc) \
+ && export CXX=$(which mpic++) \
  && git clone https://github.com/openbraininstitute/libsonatareport.git --recursive --depth 1 -b $LIBSONATAREPORT_TAG \
  && cmake -B rep_build -S libsonatareport -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCMAKE_BUILD_TYPE=Release -DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=ON .. \
  && cmake --build rep_build --parallel \
@@ -69,7 +71,7 @@ RUN source $USR_VENV/bin/activate \
 # Build h5py with the local hdf5
 RUN source $USR_VENV/bin/activate \
  && pip install mpi4py \
- && ARCH=$(uname -m) CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/mpich HDF5_LIBDIR=/usr/lib/$ARCH-linux-gnu/hdf5/mpich \
+ && ARCH=$(uname -m) CC="mpicc" HDF5_MPI="ON" HDF5_INCLUDEDIR=/usr/include/hdf5/openmpi HDF5_LIBDIR=/usr/lib/$ARCH-linux-gnu/hdf5/openmpi \
     pip install --no-cache-dir --no-binary=h5py h5py --no-build-isolation
 
 # Install neurodamus and prepare HOC_LIBRARY_PATH

--- a/docker/build_neurodamus.sh
+++ b/docker/build_neurodamus.sh
@@ -3,8 +3,8 @@
 echo "build models from folder " $1
 
 ARCH="x86_64"
-NRNIVMODL_INCLUDE_FLAGS="-I${SONATAREPORT_DIR}/include -I/usr/include/hdf5/mpich -I/usr/lib/${ARCH}-linux-gnu/mpich"
-NRNIVMODL_LOAD_FLAGS="-L${SONATAREPORT_DIR}/lib -lsonatareport -Wl,-rpath,${SONATAREPORT_DIR}/lib -L/usr/lib/${ARCH}-linux-gnu/hdf5/mpich -lhdf5 -Wl,-rpath,/usr/lib/${ARCH}-linux-gnu/hdf5/mpich/ -L/usr/lib/${ARCH}-linux-gnu/ -lmpich -Wl,-rpath,/usr/lib/${ARCH}-linux-gnu/"
+NRNIVMODL_INCLUDE_FLAGS="-I${SONATAREPORT_DIR}/include -I/usr/include/hdf5/openmpi -I/usr/lib/${ARCH}-linux-gnu/openmpi"
+NRNIVMODL_LOAD_FLAGS="-L${SONATAREPORT_DIR}/lib -lsonatareport -Wl,-rpath,${SONATAREPORT_DIR}/lib -L/usr/lib/${ARCH}-linux-gnu/hdf5/openmpi -lhdf5 -Wl,-rpath,/usr/lib/${ARCH}-linux-gnu/hdf5/openmpi/ -L/usr/lib/${ARCH}-linux-gnu/ -lmpi -Wl,-rpath,/usr/lib/${ARCH}-linux-gnu/"
 
 if [[ "$2" == "--only-neuron" ]]; then
     nrnivmodl -incflags ${NRNIVMODL_INCLUDE_FLAGS} -loadflags ${NRNIVMODL_LOAD_FLAGS} "$1"


### PR DESCRIPTION
## Context
PR #507 revealed some inconsistencies in memory measurement between MPICH and OpenMPI (in particular the heap memory measured via memray in multi ranks), which affected the dry run mpi test results in the integration CI workflow. The measurement in openMPI was more stable. As we use OpenMPI on AWS, and for unit coverage CI workflow, it is better to use the same setting for the integration CI workflow. 

## Scope
Use `openmpi` in `simulation_test.yml` and `docker/Dockerfile`

## Testing
Existing ones

## Review
* [x] PR description is complete
* [x] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
