### PR TITLE
adapt to new libsonata

### DIFF
--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -262,7 +262,7 @@ class _SimConfig:
         from . import NeuronWrapper as Nd
 
         if isinstance(config_file, str):
-            if not os.path.isfile(config_file):
+            if not Path(config_file).is_file():
                 raise ConfigurationError("Config file not found: " + config_file)
             cls.config_file = config_file
             cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -261,18 +261,24 @@ class _SimConfig:
         # Import these objects scope-level to avoid cross module dependency
         from . import NeuronWrapper as Nd
 
-        Nd.init()
-        if not os.path.isfile(config_file):
-            raise ConfigurationError("Config file not found: " + config_file)
-        logging.info("Initializing Simulation Configuration and Validation")
+        if isinstance(config_file, str):
+            if not os.path.isfile(config_file):
+                raise ConfigurationError("Config file not found: " + config_file)
+            cls.config_file = config_file
+            cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))
+        else:
+            cls.config_file = None
+            cls.simulation_config_dir = config_file.base_path
 
-        log_verbose("ConfigFile: %s", config_file)
-        log_verbose("CLI Options: %s", cli_options)
-        cls.config_file = config_file
         cls._config_parser = cls._init_config_parser(config_file)
+
+        use_color = (cli_options or {}).pop("use_color", True)
+        log_file = cls._config_parser._sim_conf.output.log_file
+        Nd.init(log_filename=log_file, log_use_color=use_color)
+
+        logging.info("Initializing Simulation Configuration and Validation")
         cls._parsed_run = cls._config_parser.parsedRun
         cls._simulation_config = cls._config_parser  # Please refactor me
-        cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))
         log_verbose(
             "SimulationConfigDir using directory of simulation config file: %s",
             cls.simulation_config_dir,
@@ -370,16 +376,11 @@ class _SimConfig:
 
     @classmethod
     def _init_config_parser(cls, config_file):
-        if not config_file.endswith(".json"):
+        if isinstance(config_file, str) and not config_file.endswith(".json"):
             raise ConfigurationError(
                 "Invalid configuration file format. The configuration file must be a .json file."
             )
-        try:
-            config_parser = SonataConfig(config_file)
-        except Exception as e:
-            msg = f"Failed to initialize SonataConfig with {config_file}"
-            raise ConfigurationError(msg) from e
-        return config_parser
+        return SonataConfig(config_file)
 
     @classmethod
     def _init_hoc_config_objs(cls):

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -284,6 +284,8 @@ class _SimConfig:
         cls._config_parser = SonataConfig(sim_config)
 
         logging.info("Initializing Simulation Configuration and Validation")
+        log_verbose("ConfigFile: %s", config_file)
+        log_verbose("CLI Options: %s", cli_options)
         cls._parsed_run = cls._config_parser.parsedRun
         cls._simulation_config = cls._config_parser  # Please refactor me
         log_verbose(

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -257,39 +257,30 @@ class _SimConfig:
     cell_requirements = property(lambda self: self._cell_requirements)
 
     @classmethod
-    def init(cls, config_file, cli_options):
-        # Import these objects scope-level to avoid cross module dependency
+    def init(
+        cls, sim_config: libsonata.SimulationConfig, cli_options, config_file: str | None = None
+    ):
+        """Initialize the simulation configuration.
+
+        Args:
+            sim_config: A ``libsonata.SimulationConfig`` instance.
+            cli_options: A dictionary of CLI options.
+            config_file: The original config file path, or None if a
+                SimulationConfig object was passed directly.
+        """
+        # Import scope-level to avoid cross module dependency
         from . import NeuronWrapper as Nd
 
-        # 1. Resolve to a libsonata.SimulationConfig object
-        if isinstance(config_file, str):
-            if not config_file.endswith(".json"):
-                raise ConfigurationError(
-                    "Invalid configuration file format."
-                    " The configuration file must be a .json file."
-                )
-            if not Path(config_file).is_file():
-                raise ConfigurationError("Config file not found: " + config_file)
-            cls.config_file = config_file
-            cls.simulation_config_dir = str(Path(config_file).resolve().parent)
-            sim_config_obj = libsonata.SimulationConfig.from_file(config_file)
-        elif isinstance(config_file, libsonata.SimulationConfig):
-            cls.config_file = None
-            cls.simulation_config_dir = config_file.base_path
-            sim_config_obj = config_file
-        else:
-            raise ConfigurationError(
-                f"Invalid config_file type: {type(config_file)}. "
-                "Expected a file path (str) or libsonata.SimulationConfig."
-            )
+        # Ensure NEURON is initialized (no-op if already done by Node)
+        Nd.init()
 
-        # 2. Set up logging (before any parsing that may log)
-        use_color = (cli_options or {}).pop("use_color", True)
-        log_file = sim_config_obj.output.log_file
-        Nd.init(log_filename=log_file, log_use_color=use_color)
+        cls.config_file = config_file
+        cls.simulation_config_dir = (
+            str(Path(config_file).resolve().parent) if config_file else sim_config.base_path
+        )
 
-        # 3. Parse the full config (now logging is available)
-        cls._config_parser = SonataConfig(sim_config_obj)
+        # Parse the full config
+        cls._config_parser = SonataConfig(sim_config)
 
         logging.info("Initializing Simulation Configuration and Validation")
         cls._parsed_run = cls._config_parser.parsedRun

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -205,7 +205,6 @@ class LoadBalanceMode(Enum):
 class _SimConfig:
     """A class initializing several HOC config objects and proxying to simConfig"""
 
-    config_file = None
     cli_options = None
     run_conf = None
     output_root = None
@@ -257,34 +256,24 @@ class _SimConfig:
     cell_requirements = property(lambda self: self._cell_requirements)
 
     @classmethod
-    def init(
-        cls, sim_config: libsonata.SimulationConfig, cli_options, config_file: str | None = None
-    ):
+    def init(cls, sim_config: libsonata.SimulationConfig, cli_options):
         """Initialize the simulation configuration.
 
         Args:
             sim_config: A ``libsonata.SimulationConfig`` instance.
             cli_options: A dictionary of CLI options.
-            config_file: The original config file path (e.g.
-                ``"simulation_config.json"``), or None if ``sim_config``
-                was built from a JSON string via
-                ``libsonata.SimulationConfig(json_str, base_path)``.
         """
         # Import scope-level to avoid cross module dependency
         from . import NeuronWrapper as Nd
 
         # Ensure NEURON is initialized (no-op if already done by Node)
         Nd.init()
-        cls.config_file = config_file
-        cls.simulation_config_dir = (
-            str(Path(config_file).resolve().parent) if config_file else sim_config.base_path
-        )
+        cls.simulation_config_dir = sim_config.base_path
 
         # Parse the full config
         cls._config_parser = SonataConfig(sim_config)
 
         logging.info("Initializing Simulation Configuration and Validation")
-        log_verbose("ConfigFile: %s", config_file)
         log_verbose("CLI Options: %s", cli_options)
         cls._parsed_run = cls._config_parser.parsedRun
         cls._simulation_config = cls._config_parser  # Please refactor me

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -266,9 +266,14 @@ class _SimConfig:
                 raise ConfigurationError("Config file not found: " + config_file)
             cls.config_file = config_file
             cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))
-        else:
+        elif isinstance(config_file, libsonata.SimulationConfig):
             cls.config_file = None
             cls.simulation_config_dir = config_file.base_path
+        else:
+            raise ConfigurationError(
+                f"Invalid config_file type: {type(config_file)}. "
+                "Expected a file path (str) or libsonata.SimulationConfig."
+            )
 
         cls._config_parser = cls._init_config_parser(config_file)
 

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -261,25 +261,35 @@ class _SimConfig:
         # Import these objects scope-level to avoid cross module dependency
         from . import NeuronWrapper as Nd
 
+        # 1. Resolve to a libsonata.SimulationConfig object
         if isinstance(config_file, str):
+            if not config_file.endswith(".json"):
+                raise ConfigurationError(
+                    "Invalid configuration file format."
+                    " The configuration file must be a .json file."
+                )
             if not Path(config_file).is_file():
                 raise ConfigurationError("Config file not found: " + config_file)
             cls.config_file = config_file
-            cls.simulation_config_dir = os.path.dirname(os.path.abspath(config_file))
+            cls.simulation_config_dir = str(Path(config_file).resolve().parent)
+            sim_config_obj = libsonata.SimulationConfig.from_file(config_file)
         elif isinstance(config_file, libsonata.SimulationConfig):
             cls.config_file = None
             cls.simulation_config_dir = config_file.base_path
+            sim_config_obj = config_file
         else:
             raise ConfigurationError(
                 f"Invalid config_file type: {type(config_file)}. "
                 "Expected a file path (str) or libsonata.SimulationConfig."
             )
 
-        cls._config_parser = cls._init_config_parser(config_file)
-
+        # 2. Set up logging (before any parsing that may log)
         use_color = (cli_options or {}).pop("use_color", True)
-        log_file = cls._config_parser._sim_conf.output.log_file
+        log_file = sim_config_obj.output.log_file
         Nd.init(log_filename=log_file, log_use_color=use_color)
+
+        # 3. Parse the full config (now logging is available)
+        cls._config_parser = SonataConfig(sim_config_obj)
 
         logging.info("Initializing Simulation Configuration and Validation")
         cls._parsed_run = cls._config_parser.parsedRun
@@ -378,14 +388,6 @@ class _SimConfig:
         if create:
             outdir.mkdir(parents=True, exist_ok=True)
         return str(outdir)
-
-    @classmethod
-    def _init_config_parser(cls, config_file):
-        if isinstance(config_file, str) and not config_file.endswith(".json"):
-            raise ConfigurationError(
-                "Invalid configuration file format. The configuration file must be a .json file."
-            )
-        return SonataConfig(config_file)
 
     @classmethod
     def _init_hoc_config_objs(cls):

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -273,7 +273,6 @@ class _SimConfig:
 
         # Ensure NEURON is initialized (no-op if already done by Node)
         Nd.init()
-
         cls.config_file = config_file
         cls.simulation_config_dir = (
             str(Path(config_file).resolve().parent) if config_file else sim_config.base_path

--- a/neurodamus/core/configuration.py
+++ b/neurodamus/core/configuration.py
@@ -265,8 +265,10 @@ class _SimConfig:
         Args:
             sim_config: A ``libsonata.SimulationConfig`` instance.
             cli_options: A dictionary of CLI options.
-            config_file: The original config file path, or None if a
-                SimulationConfig object was passed directly.
+            config_file: The original config file path (e.g.
+                ``"simulation_config.json"``), or None if ``sim_config``
+                was built from a JSON string via
+                ``libsonata.SimulationConfig(json_str, base_path)``.
         """
         # Import scope-level to avoid cross module dependency
         from . import NeuronWrapper as Nd

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -93,24 +93,10 @@ class SonataConfig:
         "_circuit_conf",  # libsonata.CircuitConfig
         "_circuits",
         "_sim_conf",  # libsonata.SimulationConfig
-        # Currently, the `inputs` of a simulation_config is a json object,
-        # which is unordered; however, the order of stimuli matter, so try and
-        # recover the order defined in the json file: this assumes that `json.load`
-        # keeps it; *which is not guaranteed* see the discussion:
-        # https://github.com/openbraininstitute/neurodamus/issues/217#issuecomment-2827930163
-        # the SONATA specification should be updated to be a list
-        "_stable_inputs_order",
     )
 
     def __init__(self, config_path):
         self._sim_conf = libsonata.SimulationConfig.from_file(config_path)
-
-        with open(config_path, encoding="utf-8") as fd:
-            if inputs := json.load(fd).get("inputs", None):
-                self._stable_inputs_order = tuple(inputs.keys())
-            else:
-                self._stable_inputs_order = ()
-
         self._circuit_conf = libsonata.CircuitConfig.from_file(self._sim_conf.network)
         self._circuits = self._extract_circuits_info()
 
@@ -342,7 +328,7 @@ class SonataConfig:
         # TODO: loop over self._sim_conf.inputs() list after updating SONATA SPEC and libsonata API,
         # The order of stimulus injection could lead to minor difference on the results
         # so need to preserve it as in the config file
-        for name in self._stable_inputs_order:
+        for name in self._sim_conf.list_input_names:
             stimulus = self._translate_dict(item_translation, self._sim_conf.input(name))
             self._adapt_libsonata_fields(stimulus)
             stimulus["Pattern"] = module_translation.get(

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -95,8 +95,17 @@ class SonataConfig:
         "_sim_conf",  # libsonata.SimulationConfig
     )
 
-    def __init__(self, config_path):
-        self._sim_conf = libsonata.SimulationConfig.from_file(config_path)
+    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig):
+        """Initialize SonataConfig from a file path or a SimulationConfig object.
+
+        Args:
+            config_path_or_obj: Path to a SONATA simulation config JSON file,
+                or a pre-built ``libsonata.SimulationConfig`` object.
+        """
+        if isinstance(config_path_or_obj, str):
+            self._sim_conf = libsonata.SimulationConfig.from_file(config_path_or_obj)
+        else:
+            self._sim_conf = config_path_or_obj
         self._circuit_conf = libsonata.CircuitConfig.from_file(self._sim_conf.network)
         self._circuits = self._extract_circuits_info()
 

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -95,17 +95,13 @@ class SonataConfig:
         "_sim_conf",  # libsonata.SimulationConfig
     )
 
-    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig):
-        """Initialize SonataConfig from a file path or a SimulationConfig object.
+    def __init__(self, sim_config: libsonata.SimulationConfig):
+        """Initialize SonataConfig from a SimulationConfig instance.
 
         Args:
-            config_path_or_obj: Path to a SONATA simulation config JSON file,
-                or a ``libsonata.SimulationConfig`` instance.
+            sim_config: A ``libsonata.SimulationConfig`` instance.
         """
-        if isinstance(config_path_or_obj, str):
-            self._sim_conf = libsonata.SimulationConfig.from_file(config_path_or_obj)
-        else:
-            self._sim_conf = config_path_or_obj
+        self._sim_conf = sim_config
         self._circuit_conf = libsonata.CircuitConfig.from_file(self._sim_conf.network)
         self._circuits = self._extract_circuits_info()
 

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -100,7 +100,7 @@ class SonataConfig:
 
         Args:
             config_path_or_obj: Path to a SONATA simulation config JSON file,
-                or a pre-built ``libsonata.SimulationConfig`` object.
+                or a ``libsonata.SimulationConfig`` instance.
         """
         if isinstance(config_path_or_obj, str):
             self._sim_conf = libsonata.SimulationConfig.from_file(config_path_or_obj)

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -334,33 +334,33 @@ class Node:
     _default_population = "All"
     """The default population name for e.g. Reports."""
 
-    def __init__(self, config_file, options: dict | None = None):
+    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig,
+                 options: dict | None = None):
         """Creates a neurodamus executor
+
         Args:
-            config_file: A Sonata config file
+            config_path_or_obj: Path to a SONATA simulation config JSON file,
+                or a pre-built ``libsonata.SimulationConfig`` object.
             options: A dictionary of run options typically coming from cmd line
         """
         options = options or {}
-        assert isinstance(config_file, str), "`config_file` should be a string"
-        assert config_file, "`config_file` cannot be empty"
 
-        if config_file.endswith("BlueConfig"):
-            raise ConfigurationError(
-                "Legacy format BlueConfig is not supported, please migrate to SONATA config"
-            )
-        import libsonata
-
-        conf = libsonata.SimulationConfig.from_file(config_file)
-        Nd.init(log_filename=conf.output.log_file, log_use_color=options.pop("use_color", True))
+        if isinstance(config_path_or_obj, str):
+            assert config_path_or_obj, "`config_path_or_obj` cannot be empty"
+            if config_path_or_obj.endswith("BlueConfig"):
+                raise ConfigurationError(
+                    "Legacy format BlueConfig is not supported, please migrate to SONATA config"
+                )
 
         # This is global initialization, happening once, regardless of number of
         # cycles
         log_stage("Setting up Neurodamus configuration")
+        SimConfig.init(config_path_or_obj, options)
+
         self._pc = Nd.pc
         self._spike_vecs = []
         self._spike_populations = []
         Nd.execute("cvode = new CVode()")
-        SimConfig.init(config_file, options)
 
         if SimConfig.use_coreneuron:
             # Instantiate the CoreNEURON artificial cell object which is used to fill up
@@ -1594,7 +1594,8 @@ class Node:
 class Neurodamus(Node):
     """A high level interface to Neurodamus"""
 
-    def __init__(self, config_file, logging_level=None, **user_opts):
+    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig,
+                 logging_level=None, **user_opts):
         """Creates and initializes a neurodamus run node
 
         As part of Initiazation it calls:
@@ -1605,7 +1606,8 @@ class Neurodamus(Node):
          * Activate reports if requested
 
         Args:
-            config_file: The simulation config recipe file
+            config_path_or_obj: Path to a SONATA simulation config JSON file,
+                or a pre-built ``libsonata.SimulationConfig`` object.
             logging_level: (int) Redefine the global logging level.
                 0 - Only warnings / errors
                 1 - Info messages (default)
@@ -1617,7 +1619,7 @@ class Neurodamus(Node):
         if logging_level is not None:
             GlobalConfig.verbosity = logging_level
 
-        Node.__init__(self, config_file, user_opts)
+        Node.__init__(self, config_path_or_obj, user_opts)
         # Use the run_conf dict to avoid passing it around
         self._run_conf.enable_reports = enable_reports
 
@@ -1638,8 +1640,9 @@ class Neurodamus(Node):
             self._instantiate_simulation()
 
         # Remove .SUCCESS file if exists
-        self._success_file = SimConfig.config_file + ".SUCCESS"
-        self._remove_file(self._success_file)
+        self._success_file = SimConfig.config_file + ".SUCCESS" if SimConfig.config_file else None
+        if self._success_file:
+            self._remove_file(self._success_file)
 
     # -
     def _build_single_model(self):
@@ -1927,8 +1930,14 @@ class Neurodamus(Node):
             self.run_all()
 
         # Create SUCCESS file if the simulation finishes successfully
-        self._touch_file(self._success_file)
-        logging.info("Finished! Creating .SUCCESS file: '%s'", self._success_file)
+        if self._success_file:
+            self._touch_file(self._success_file)
+            logging.info("Finished! Creating .SUCCESS file: '%s'", self._success_file)
+        else:
+            logging.info(
+                "Finished! Skipping .SUCCESS file creation:"
+                " config was passed as a libsonata.SimulationConfig object (no file path)"
+            )
 
         # Save seclamp holding currents for gap junction user corrections
         if (

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -334,8 +334,9 @@ class Node:
     _default_population = "All"
     """The default population name for e.g. Reports."""
 
-    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig,
-                 options: dict | None = None):
+    def __init__(
+        self, config_path_or_obj: str | libsonata.SimulationConfig, options: dict | None = None
+    ):
         """Creates a neurodamus executor
 
         Args:
@@ -1594,8 +1595,9 @@ class Node:
 class Neurodamus(Node):
     """A high level interface to Neurodamus"""
 
-    def __init__(self, config_path_or_obj: str | libsonata.SimulationConfig,
-                 logging_level=None, **user_opts):
+    def __init__(
+        self, config_path_or_obj: str | libsonata.SimulationConfig, logging_level=None, **user_opts
+    ):
         """Creates and initializes a neurodamus run node
 
         As part of Initiazation it calls:

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -341,7 +341,7 @@ class Node:
 
         Args:
             config_path_or_obj: Path to a SONATA simulation config JSON file,
-                or a pre-built ``libsonata.SimulationConfig`` object.
+                or a ``libsonata.SimulationConfig`` instance.
             options: A dictionary of run options typically coming from cmd line
         """
         options = options or {}
@@ -1609,7 +1609,7 @@ class Neurodamus(Node):
 
         Args:
             config_path_or_obj: Path to a SONATA simulation config JSON file,
-                or a pre-built ``libsonata.SimulationConfig`` object.
+                or a ``libsonata.SimulationConfig`` instance.
             logging_level: (int) Redefine the global logging level.
                 0 - Only warnings / errors
                 1 - Info messages (default)

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -346,13 +346,16 @@ class Node:
         """
         options = options or {}
 
-        if isinstance(config_path_or_obj, str):
-            assert config_path_or_obj, "`config_path_or_obj` cannot be empty"
+        sim_config_obj, config_file = self._get_simulation_config(config_path_or_obj)
+        Nd.init(
+            log_filename=sim_config_obj.output.log_file,
+            log_use_color=options.pop("use_color", True),
+        )
 
         # This is global initialization, happening once, regardless of number of
         # cycles
-        SimConfig.init(config_path_or_obj, options)
         log_stage("Setting up Neurodamus configuration")
+        SimConfig.init(sim_config_obj, options, config_file=config_file)
 
         self._pc = Nd.pc
         self._spike_vecs = []
@@ -383,6 +386,35 @@ class Node:
         self._dry_run_stats = None
 
         self._reset()
+
+    @staticmethod
+    def _get_simulation_config(config_path_or_obj):
+        """Resolve a path or SimulationConfig object into a validated SimulationConfig.
+
+        Args:
+            config_path_or_obj: Path to a SONATA simulation config JSON file,
+                or a ``libsonata.SimulationConfig`` instance.
+
+        Returns:
+            Tuple of (SimulationConfig object, config file path or None)
+        """
+        if isinstance(config_path_or_obj, str):
+            if not config_path_or_obj:
+                raise ConfigurationError("`config_path_or_obj` cannot be empty")
+            if not config_path_or_obj.endswith(".json"):
+                raise ConfigurationError(
+                    "Invalid configuration file format."
+                    " The configuration file must be a .json file."
+                )
+            if not Path(config_path_or_obj).is_file():
+                raise ConfigurationError("Config file not found: " + config_path_or_obj)
+            return libsonata.SimulationConfig.from_file(config_path_or_obj), config_path_or_obj
+        if isinstance(config_path_or_obj, libsonata.SimulationConfig):
+            return config_path_or_obj, None
+        raise ConfigurationError(
+            f"Invalid config_path_or_obj type: {type(config_path_or_obj)}. "
+            "Expected a file path (str) or libsonata.SimulationConfig."
+        )
 
     def _reset(self):
         """Resets internal state for a new simulation cycle.

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -351,8 +351,8 @@ class Node:
 
         # This is global initialization, happening once, regardless of number of
         # cycles
-        log_stage("Setting up Neurodamus configuration")
         SimConfig.init(config_path_or_obj, options)
+        log_stage("Setting up Neurodamus configuration")
 
         self._pc = Nd.pc
         self._spike_vecs = []

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -355,7 +355,9 @@ class Node:
         # This is global initialization, happening once, regardless of number of
         # cycles
         log_stage("Setting up Neurodamus configuration")
-        SimConfig.init(sim_config_obj, options, config_file=config_file)
+        SimConfig.init(sim_config_obj, options)
+
+        self._config_file = config_file
 
         self._pc = Nd.pc
         self._spike_vecs = []
@@ -1670,7 +1672,7 @@ class Neurodamus(Node):
             self._instantiate_simulation()
 
         # Remove .SUCCESS file if exists
-        self._success_file = SimConfig.config_file + ".SUCCESS" if SimConfig.config_file else None
+        self._success_file = self._config_file + ".SUCCESS" if self._config_file else None
         if self._success_file:
             self._remove_file(self._success_file)
 

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -348,10 +348,6 @@ class Node:
 
         if isinstance(config_path_or_obj, str):
             assert config_path_or_obj, "`config_path_or_obj` cannot be empty"
-            if config_path_or_obj.endswith("BlueConfig"):
-                raise ConfigurationError(
-                    "Legacy format BlueConfig is not supported, please migrate to SONATA config"
-                )
 
         # This is global initialization, happening once, regardless of number of
         # cycles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 dependencies = [
     "h5py",
     "docopt-ng",
-    "libsonata>=0.1.34",
+    "libsonata>=0.1.35",
     "psutil",
     "packaging",
     "scipy"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import pytest
 import platform
 from pathlib import Path
 
+import libsonata
+
 from neurodamus.core._utils import run_only_rank0
 
 try:
@@ -171,6 +173,32 @@ def _is_valid_relative_path(filepath: str):
     )
 
 
+@pytest.fixture
+def create_tmp_simulation_config(request):
+    """Create a simulation config file in tmp_path and return a SimulationConfig object.
+
+    The JSON file is still written to disk for debugging purposes.
+
+    Sources (in order of priority):
+        1. simconfig_fixture in request: fixture's name (str)
+        2. or simconfig_data in request: dict
+        3. or copy of simconfig_file in request, and attach relative paths to src_dir
+    Updates the config file with extra_config.
+    Returns a libsonata.SimulationConfig instance.
+    """
+    try:
+        tmp_path = request.getfixturevalue("mpi_tmp_path")
+    except pytest.FixtureLookupError:
+        tmp_path = request.getfixturevalue("tmp_path")
+    params = request.param
+    sim_config_data = None
+    if "simconfig_fixture" in params:
+        sim_config_data = request.getfixturevalue(params.get("simconfig_fixture"))
+    config_file = _create_simulation_config_file(params, tmp_path, sim_config_data)
+    return libsonata.SimulationConfig.from_file(config_file)
+
+
+# Keep the old fixture for tests that need the file path (e.g. Neurodamus/Node entry points)
 @pytest.fixture
 def create_tmp_simulation_config_file(request):
     """create simulation config file in tmp_path from

--- a/tests/unit/test_circuitconfig.py
+++ b/tests/unit/test_circuitconfig.py
@@ -5,6 +5,7 @@ which is usually translated from a SONATA config file done in sonata_config.py
 """
 
 import pytest
+import libsonata
 
 from tests.conftest import RINGTEST_DIR
 
@@ -25,7 +26,7 @@ def test_ringtest_circuitconf(create_tmp_simulation_config_file):
     """
     test the usual flow: read a sonata config file and convert it to CircuitConfig
     """
-    config_parser = SonataConfig(create_tmp_simulation_config_file)
+    config_parser = SonataConfig(libsonata.SimulationConfig.from_file(create_tmp_simulation_config_file))
     circuit_dict = config_parser.Circuit.get("RingA")
     circuit_conf = make_circuit_config(circuit_dict)
     assert circuit_conf.as_dict() == {

--- a/tests/unit/test_circuitconfig.py
+++ b/tests/unit/test_circuitconfig.py
@@ -5,7 +5,6 @@ which is usually translated from a SONATA config file done in sonata_config.py
 """
 
 import pytest
-import libsonata
 
 from tests.conftest import RINGTEST_DIR
 
@@ -14,7 +13,7 @@ from neurodamus.io.sonata_config import SonataConfig
 
 
 @pytest.mark.parametrize(
-    "create_tmp_simulation_config_file",
+    "create_tmp_simulation_config",
     [
         {
             "simconfig_fixture": "ringtest_baseconfig",
@@ -22,11 +21,11 @@ from neurodamus.io.sonata_config import SonataConfig
     ],
     indirect=True,
 )
-def test_ringtest_circuitconf(create_tmp_simulation_config_file):
+def test_ringtest_circuitconf(create_tmp_simulation_config):
     """
     test the usual flow: read a sonata config file and convert it to CircuitConfig
     """
-    config_parser = SonataConfig(libsonata.SimulationConfig.from_file(create_tmp_simulation_config_file))
+    config_parser = SonataConfig(create_tmp_simulation_config)
     circuit_dict = config_parser.Circuit.get("RingA")
     circuit_conf = make_circuit_config(circuit_dict)
     assert circuit_conf.as_dict() == {

--- a/tests/unit/test_modifications.py
+++ b/tests/unit/test_modifications.py
@@ -179,54 +179,6 @@ def test_configure_all_sections_AugAssign(create_tmp_simulation_config_file):
     assert np.isclose(soma2.e_pas, -7)
 
 
-@pytest.mark.parametrize(
-    "create_tmp_simulation_config_file",
-    [
-        {
-            "simconfig_fixture": "ringtest_baseconfig",
-            "extra_config": {
-                "target_simulator": "NEURON",
-                "conditions": {
-                    "modifications": [
-                        {
-                            "name": "no_SK_E2",
-                            "node_set": "RingA:oneCell",
-                            "type": "configure_all_sections",
-                            "section_configure": "%s.e_pas *= 0.1",
-                        },
-                        {
-                            "name": "no_SK_E2",
-                            "node_set": "RingA:oneCell",
-                            "type": "configure_all_sections",
-                            "section_configure": "%s.gnabar_hh *= 11",
-                        }
-
-                    ]
-                },
-            },
-        }
-    ],
-    indirect=True,
-)
-def test_configure_all_sections_AugAssign_name_clash(create_tmp_simulation_config_file):
-    """This should produce the same results as test_configure_all_sections_AugAssign
-    
-    However, here we apply the same modification in 2 steps with modifications 
-    that have the same name. Their combined effect should be equivalent 
-    to the modification in test_configure_all_sections_AugAssign.
-    """
-
-    # NeuronWrapper needs to be imported at function level
-    from neurodamus.core import NeuronWrapper as Nd
-
-    Neurodamus(create_tmp_simulation_config_file)
-    soma1 = Nd._pc.gid2cell(0).soma[0]
-    soma2 = Nd._pc.gid2cell(1).soma[0]
-
-    assert np.isclose(soma1.gnabar_hh, 0.12)
-    assert np.isclose(soma1.e_pas, -70)
-    assert np.isclose(soma2.gnabar_hh, 1.32)
-    assert np.isclose(soma2.e_pas, -7)
 
 @pytest.mark.parametrize(
     "create_tmp_simulation_config_file",

--- a/tests/unit/test_modifications.py
+++ b/tests/unit/test_modifications.py
@@ -2,6 +2,7 @@ import json
 import re
 from tempfile import NamedTemporaryFile
 
+import libsonata
 import numpy as np
 import pytest
 
@@ -697,10 +698,7 @@ def test_modification_wrong_target_multiple_types(
     else:
         error_message = "Could not find 'node_set' in 'modification 0'"
 
-    with pytest.raises(
-        Exception,
-        match=error_message,
-    ):
+    with pytest.raises(libsonata.SonataError, match=error_message):
         Neurodamus(sim_file_path)
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_modifications.py
+++ b/tests/unit/test_modifications.py
@@ -196,6 +196,12 @@ def test_configure_all_sections_AugAssign(create_tmp_simulation_config_file):
                             "section_configure": "%s.gnabar_hh *= 10",
                         },
                         {
+                            "name": "scale_e_pas",
+                            "node_set": "RingA:oneCell",
+                            "type": "configure_all_sections",
+                            "section_configure": "%s.e_pas *= 0.1",
+                        },
+                        {
                             "name": "offset_gnabar",
                             "node_set": "RingA:oneCell",
                             "type": "configure_all_sections",
@@ -211,12 +217,16 @@ def test_configure_all_sections_AugAssign(create_tmp_simulation_config_file):
 def test_configure_all_sections_two_modifications_same_variable_ordered(
     create_tmp_simulation_config_file,
 ):
-    """Two separate modifications on the same variable are both applied in declaration order.
+    """Multiple modifications on the same sections are applied in declaration order.
 
-    gnabar_hh starts at 0.12 for cell 1 (RingA:oneCell).
-    First modification: *= 10 -> 1.2
-    Second modification: += 1 -> 2.2
-    If order were reversed the result would be (0.12 + 1) * 10 = 11.2.
+    Also verifies that a modification on a different variable (e_pas) does not
+    interfere with the two modifications on gnabar_hh.
+
+    gnabar_hh starts at 0.12, e_pas at -70 for cell 1 (RingA:oneCell).
+    1. gnabar_hh *= 10 -> 1.2
+    2. e_pas *= 0.1    -> -7.0
+    3. gnabar_hh += 1  -> 2.2
+    If gnabar_hh order were reversed the result would be (0.12 + 1) * 10 = 11.2.
     """
 
     from neurodamus.core import NeuronWrapper as Nd
@@ -227,8 +237,11 @@ def test_configure_all_sections_two_modifications_same_variable_ordered(
 
     # Cell 0 not in target, unchanged
     assert np.isclose(soma1.gnabar_hh, 0.12)
-    # Cell 1: 0.12 * 10 + 1 = 2.2
+    assert np.isclose(soma1.e_pas, -70)
+    # Cell 1: gnabar_hh = 0.12 * 10 + 1 = 2.2
     assert np.isclose(soma2.gnabar_hh, 2.2)
+    # Cell 1: e_pas = -70 * 0.1 = -7.0
+    assert np.isclose(soma2.e_pas, -7.0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_modifications.py
+++ b/tests/unit/test_modifications.py
@@ -180,6 +180,56 @@ def test_configure_all_sections_AugAssign(create_tmp_simulation_config_file):
     assert np.isclose(soma2.e_pas, -7)
 
 
+@pytest.mark.parametrize(
+    "create_tmp_simulation_config_file",
+    [
+        {
+            "simconfig_fixture": "ringtest_baseconfig",
+            "extra_config": {
+                "target_simulator": "NEURON",
+                "conditions": {
+                    "modifications": [
+                        {
+                            "name": "scale_gnabar",
+                            "node_set": "RingA:oneCell",
+                            "type": "configure_all_sections",
+                            "section_configure": "%s.gnabar_hh *= 10",
+                        },
+                        {
+                            "name": "offset_gnabar",
+                            "node_set": "RingA:oneCell",
+                            "type": "configure_all_sections",
+                            "section_configure": "%s.gnabar_hh += 1",
+                        }
+                    ]
+                },
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_configure_all_sections_two_modifications_same_variable_ordered(
+    create_tmp_simulation_config_file,
+):
+    """Two separate modifications on the same variable are both applied in declaration order.
+
+    gnabar_hh starts at 0.12 for cell 1 (RingA:oneCell).
+    First modification: *= 10 -> 1.2
+    Second modification: += 1 -> 2.2
+    If order were reversed the result would be (0.12 + 1) * 10 = 11.2.
+    """
+
+    from neurodamus.core import NeuronWrapper as Nd
+
+    Neurodamus(create_tmp_simulation_config_file)
+    soma1 = Nd._pc.gid2cell(0).soma[0]
+    soma2 = Nd._pc.gid2cell(1).soma[0]
+
+    # Cell 0 not in target, unchanged
+    assert np.isclose(soma1.gnabar_hh, 0.12)
+    # Cell 1: 0.12 * 10 + 1 = 2.2
+    assert np.isclose(soma2.gnabar_hh, 2.2)
+
 
 @pytest.mark.parametrize(
     "create_tmp_simulation_config_file",

--- a/tests/unit/test_replay_manager.py
+++ b/tests/unit/test_replay_manager.py
@@ -115,7 +115,7 @@ def test_error_replay_format():
         SpikeManager("out.dat")
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -133,8 +133,8 @@ def test_error_replay_format():
     },
 ], indirect=True)
 @pytest.mark.forked
-def test_sonata_parse_synapse_replay_input(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_sonata_parse_synapse_replay_input(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
 
     assert len(SimConfig.stimuli) == 1
     spikes_replay = SimConfig.stimuli[0]

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -285,3 +285,21 @@ def test_parse_inputs(create_tmp_simulation_config_file):
         "PercentLess": 50.0
     }
     assert SimConfig.stimuli[2] == utils.merge_dicts(SimConfig.stimuli[2], expected_input_subthreshold)
+
+
+def test_sonata_config_from_simulation_config_object():
+    """SonataConfig accepts a pre-built libsonata.SimulationConfig object."""
+    import json
+
+    config_dict = {
+        "network": str(RINGTEST_DIR / "circuit_config.json"),
+        "node_sets_file": str(RINGTEST_DIR / "nodesets.json"),
+        "run": {"random_seed": 1, "dt": 0.025, "tstop": 10},
+    }
+
+    sim_conf = libsonata.SimulationConfig(json.dumps(config_dict), str(RINGTEST_DIR))
+    raw_conf = SonataConfig(sim_conf)
+
+    assert raw_conf.parsedRun.base_seed == 1
+    assert raw_conf.parsedRun.dt == 0.025
+    assert raw_conf.parsedRun.tstop == 10

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -303,3 +303,23 @@ def test_sonata_config_from_simulation_config_object():
     assert raw_conf.parsedRun.base_seed == 1
     assert raw_conf.parsedRun.dt == 0.025
     assert raw_conf.parsedRun.tstop == 10
+
+
+def test_neurodamus_accepts_simulation_config_object():
+    """Neurodamus can be initialised with a libsonata.SimulationConfig object."""
+    import json
+    from neurodamus import Neurodamus
+
+    config_dict = {
+        "network": str(RINGTEST_DIR / "circuit_config.json"),
+        "node_sets_file": str(RINGTEST_DIR / "nodesets.json"),
+        "node_set": "Mosaic",
+        "target_simulator": "NEURON",
+        "run": {"random_seed": 1122, "dt": 0.1, "tstop": 50},
+        "conditions": {"celsius": 35, "v_init": -65},
+    }
+
+    sim_conf = libsonata.SimulationConfig(json.dumps(config_dict), str(RINGTEST_DIR))
+    nd = Neurodamus(sim_conf, disable_reports=True)
+
+    assert len(nd.circuits.node_managers) > 0

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 
@@ -7,12 +8,10 @@ import libsonata
 from tests import utils
 from tests.conftest import RINGTEST_DIR
 
-import libsonata
-
 from neurodamus.core.configuration import SimConfig
 from neurodamus.io.sonata_config import SonataConfig
 from neurodamus.utils.logging import setup_logging
-import libsonata
+from neurodamus import Neurodamus
 
 
 def test_parse_base():
@@ -289,7 +288,6 @@ def test_parse_inputs(create_tmp_simulation_config_file):
 
 def test_sonata_config_from_simulation_config_object():
     """SonataConfig accepts a libsonata.SimulationConfig instance."""
-    import json
 
     config_dict = {
         "network": str(RINGTEST_DIR / "circuit_config.json"),
@@ -307,8 +305,6 @@ def test_sonata_config_from_simulation_config_object():
 
 def test_neurodamus_accepts_simulation_config_object():
     """Neurodamus can be initialised with a libsonata.SimulationConfig object."""
-    import json
-    from neurodamus import Neurodamus
 
     config_dict = {
         "network": str(RINGTEST_DIR / "circuit_config.json"),

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -21,7 +21,7 @@ def test_parse_base():
     assert raw_conf.parsedRun.base_seed == 1122
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -37,8 +37,8 @@ def test_parse_base():
         }
     },
 ], indirect=True)
-def test_parse_run(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_run(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
     # RNGSettings in hoc correctly initialized from Sonata
     assert SimConfig.rng_info.getGlobalSeed() == 1122
     assert SimConfig.rng_info.getStimulusSeed() == 42
@@ -56,7 +56,7 @@ def test_parse_run(create_tmp_simulation_config_file):
     assert SimConfig.run_conf.spike_location == libsonata.SimulationConfig.Conditions.SpikeLocation.soma
     assert SimConfig.run_conf.extracellular_calcium == 1.2
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -71,15 +71,15 @@ def test_parse_run(create_tmp_simulation_config_file):
         }
     },
 ], indirect=True)
-def test_extracellular_calcium_warning(create_tmp_simulation_config_file, caplog):
+def test_extracellular_calcium_warning(create_tmp_simulation_config, caplog):
     setup_logging.logging_initted = True
     with caplog.at_level(logging.WARNING):
-        SimConfig.init(create_tmp_simulation_config_file, {})
+        SimConfig.init(create_tmp_simulation_config, {})
         assert ("Value of cao_CR_GluSynapse (2.0) is not the same as extracellular_calcium (1.2)"
                 in caplog.text)
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -95,8 +95,8 @@ def test_extracellular_calcium_warning(create_tmp_simulation_config_file, caplog
         }
     },
 ], indirect=True)
-def test_parse_conditions(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_conditions(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
 
     cond = SimConfig._simulation_config.parsedConditions
     assert cond.randomize_gaba_rise_time == False
@@ -105,7 +105,7 @@ def test_parse_conditions(create_tmp_simulation_config_file):
     assert SimConfig.run_conf.spike_location == libsonata.SimulationConfig.Conditions.SpikeLocation.AIS
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -116,8 +116,8 @@ def test_parse_conditions(create_tmp_simulation_config_file):
         }
     }
 ], indirect=True)
-def test_parse_seeds(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_seeds(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
     assert SimConfig.rng_info.getGlobalSeed() == 12345
     assert SimConfig.rng_info.getStimulusSeed() == 1122
     assert SimConfig.rng_info.getIonChannelSeed() == 0
@@ -125,7 +125,7 @@ def test_parse_seeds(create_tmp_simulation_config_file):
     assert SimConfig.rng_info.getSynapseSeed() == 0
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -147,8 +147,8 @@ def test_parse_seeds(create_tmp_simulation_config_file):
         }
     }
 ], indirect=True)
-def test_parse_modifications(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_modifications(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
     assert list(mod.name for mod in SimConfig.modifications) == ["no_SK_E2", "applyTTX"]  # order preserved
 
     ttx_mod = SimConfig.modifications[1]
@@ -162,7 +162,7 @@ def test_parse_modifications(create_tmp_simulation_config_file):
     assert configure_all_sections_mod.section_configure == "%s.gSK_E2bar_SK_E2 = 0"
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -181,8 +181,8 @@ def test_parse_modifications(create_tmp_simulation_config_file):
         }
     }
 ], indirect=True)
-def test_parse_connections(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_connections(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
     conn = SimConfig.connections[0]
 
     assert conn.name == "GABAB_erev"
@@ -197,7 +197,7 @@ def test_parse_connections(create_tmp_simulation_config_file):
     assert conn.spont_minis is None
     assert conn.modoverride is None
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -209,14 +209,14 @@ def test_parse_connections(create_tmp_simulation_config_file):
         }
     }
 ], indirect=True)
-def test_parse_ouput(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_ouput(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
     # output section
     assert SimConfig.run_conf.spikes_file == "spikes.h5"
     assert SimConfig.run_conf.spikes_sort_order == libsonata.SimulationConfig.Output.SpikesSortOrder.by_time
 
 
-@pytest.mark.parametrize("create_tmp_simulation_config_file", [
+@pytest.mark.parametrize("create_tmp_simulation_config", [
     {
         "simconfig_fixture": "ringtest_baseconfig",
         "extra_config": {
@@ -252,8 +252,8 @@ def test_parse_ouput(create_tmp_simulation_config_file):
         }
     }
 ], indirect=True)
-def test_parse_inputs(create_tmp_simulation_config_file):
-    SimConfig.init(create_tmp_simulation_config_file, {})
+def test_parse_inputs(create_tmp_simulation_config):
+    SimConfig.init(create_tmp_simulation_config, {})
 
     expected_input_hp = {
         "Pattern": "Hyperpolarizing",

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -288,7 +288,7 @@ def test_parse_inputs(create_tmp_simulation_config_file):
 
 
 def test_sonata_config_from_simulation_config_object():
-    """SonataConfig accepts a pre-built libsonata.SimulationConfig object."""
+    """SonataConfig accepts a libsonata.SimulationConfig instance."""
     import json
 
     config_dict = {

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -15,7 +15,8 @@ from neurodamus import Neurodamus
 
 
 def test_parse_base():
-    raw_conf = SonataConfig(str(RINGTEST_DIR / "simulation_config.json"))
+    sim_conf = libsonata.SimulationConfig.from_file(str(RINGTEST_DIR / "simulation_config.json"))
+    raw_conf = SonataConfig(sim_conf)
     assert raw_conf._sim_conf.run.random_seed == 1122
     assert raw_conf.parsedRun.base_seed == 1122
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,6 @@ deps =
     -r tests/requirements.txt
     coverage>=7.10.6
     pytest-cov>=7.0
-    libsonata @ file://{toxinidir}/../libsonata
-    # TODO: Remove the line above once libsonata >0.1.34 is released on PyPI,
-    #       and bump "libsonata>=0.1.34" in pyproject.toml to the new version.
 
 [testenv:baseline]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ deps =
     -r tests/requirements.txt
     coverage>=7.10.6
     pytest-cov>=7.0
+    libsonata @ file://{toxinidir}/../libsonata
+    # TODO: Remove the line above once libsonata >0.1.34 is released on PyPI,
+    #       and bump "libsonata>=0.1.34" in pyproject.toml to the new version.
 
 [testenv:baseline]
 deps =


### PR DESCRIPTION
## Context

The new libsonata brings some new small but useful features like:
- rejects duplicate modification names
- `list_input_names` now preserves order

This allows us to:
- accept a `libsonata.SimulationConfig` object instead of the path of a file. Useful for last minute patches and dummy simulation_configs. No more juggling with temp files
- simplification in a couple of places of the logic. Stuff is already handled by libsonata. Less bookkeping

## Scope

- Use `libsonata.SimulationConfig.list_input_names` directly instead of re-reading the JSON file to get input order (`_stable_inputs_order` removed)
- `SonataConfig`, `Node`, and `Neurodamus` now accept a `libsonata.SimulationConfig` object in addition to a file path
- Removed double config parsing: `Node.__init__` no longer parses the config separately — `SimConfig.init` handles everything
- Let `libsonata.SonataError` propagate naturally instead of wrapping it in `ConfigurationError`
- Skip `.SUCCESS` file creation when config is passed as an object (no file path available)

## Very small improvements/cosmetics:

- Let `libsonata.SonataError` propagate naturally instead of wrapping it in `ConfigurationError`
- Renamed `config_file` → `config_path_or_obj` with type hints and docstrings


## Testing

- Dropped `test_configure_all_sections_AugAssign_name_clash` — libsonata now rejects duplicate modification names
- Updated `test_modification_wrong_target_multiple_types` to expect `libsonata.SonataError` directly
- Added test: `test_sonata_config_from_simulation_config_object`
- Added test: `test_neurodamus_accepts_simulation_config_object`

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
