### PR TITLE
Compute segment displacements on the fly in apply_all_stimuli

### DIFF
--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -508,9 +508,9 @@ class ElectrodeSource:
         """Apply potentials to segment.extracellular._ref_e
 
         Args:
-            segment_displacements: dict mapping segment -> displacement vector (x/y/z in meters)
+            segment_displacements: list of (segment, displacement vector) tuples (x/y/z in meters)
         """
-        for segment, displacement in segment_displacements.items():
+        for segment, displacement in segment_displacements:
             section = segment.sec
             if not section.has_membrane("extracellular"):
                 section.insert("extracellular")

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -552,7 +552,6 @@ class ElectrodeSource:
             )
             self.segment_efield_integrators.append(efi)
 
-
     def __iadd__(self, other):
         """Combined with another ElectrodeSource object"""
         self.efields.extend(other.efields)

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -516,7 +516,6 @@ class ElectrodeSource:
         self.dt = dt
         self.ramp_up_time = ramp_up_time
         self.ramp_down_time = ramp_down_time
-        self.segment_displacements = {}  # {segment: displacement vectors in x/y/z w.r.t ground}
         self.segment_efield_integrators = []
 
     def delay(self, duration):
@@ -527,9 +526,13 @@ class ElectrodeSource:
         self._cur_t += duration
         return self
 
-    def apply_segment_potentials(self):
-        """Apply potentials to segment.extracellular._ref_e"""
-        for segment, displacement in self.segment_displacements.items():
+    def apply_segment_potentials(self, segment_displacements):
+        """Apply potentials to segment.extracellular._ref_e
+
+        Args:
+            segment_displacements: dict mapping segment -> displacement vector (x/y/z in meters)
+        """
+        for segment, displacement in segment_displacements.items():
             section = segment.sec
             if not section.has_membrane("extracellular"):
                 section.insert("extracellular")
@@ -562,13 +565,6 @@ class ElectrodeSource:
                 freq_vector,
             )
             self.segment_efield_integrators.append(efi)
-
-        self.cleanup()
-
-    def cleanup(self):
-        """Clear unused list variable to free memory"""
-        self.efields = None
-        self.segment_displacements = None
 
     def __iadd__(self, other):
         """Combined with another ElectrodeSource object"""

--- a/neurodamus/node.py
+++ b/neurodamus/node.py
@@ -822,7 +822,7 @@ class Node:
             self._stim_manager.interpret(target_spec, stim)
         if SimConfig.has_extracellular_stimulus:
             logging.info("Inject extracellular stimuli")
-            SpatiallyUniformEField.apply_all_stimuli()
+            SpatiallyUniformEField.apply_all_stimuli(self._target_manager._cell_manager)
 
     # -
     @mpi_no_errors

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -875,22 +875,24 @@ class SpatiallyUniformEField:
         """Apply all consolidated stimuli to their segments.
         Computes segment displacements on the fly from cell geometry.
         """
-        if not cls._instance:
-            return
+        assert cls._instance, (
+            "SpatiallyUniformEField is a singleton but was never instantiated. "
+            "Probably interpret() was not called before apply_all_stimuli()."
+        )
         for gid, es in cls._instance.stimList.items():
             cell = cell_manager.get_cell(gid)
 
             # Compute segment displacements from the ground point (soma barycenter)
             all_seg_points = cell.compute_segment_global_coordinates()
             local_seg_points = cell.compute_segment_local_coordinates()
-            soma = cell.CellRef.soma[0]
-            soma_global_position = np.array(all_seg_points[soma.name()]).mean(axis=0)
-            soma_local_position = np.array(local_seg_points[soma.name()]).mean(axis=0)
+            soma_name = cell.CellRef.soma[0].name()
+            soma_global_position = np.array(all_seg_points[soma_name]).mean(axis=0)
+            soma_local_position = np.array(local_seg_points[soma_name]).mean(axis=0)
 
             def local_to_global(pos, cell=cell, soma_local_position=soma_local_position):
                 return cell.local_to_global_coord_mapping(np.vstack([soma_local_position, pos]))[1]
 
-            segment_displacements = {}
+            segment_displacements = []
             for sec in cell.CellRef.all:
                 for seg in sec:
                     segment_position = (
@@ -905,7 +907,7 @@ class SpatiallyUniformEField:
                         else soma_global_position
                     )
                     displacement_vec = (segment_position - soma_global_position) * 1e-6
-                    segment_displacements[seg] = displacement_vec
+                    segment_displacements.append((seg, displacement_vec))
 
             es.apply_segment_potentials(segment_displacements)
 

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -881,50 +881,46 @@ class SpatiallyUniformEField(BaseStim):
                 # TODO: update iadd method to allow: self.stimList[gid] += es; raise error for now
                 self.stimList[gid] += es
             else:
-                # Add new stimulus
                 self.stimList[gid] = es
 
-                # Compute segment displacement from the ground point where potential is 0,
-                # i.e. the soma baricenter position in x/y/z
-                cell = cell_manager.get_cell(gid)
-                all_seg_points = cell.compute_segment_global_coordinates()
-                local_seg_points = cell.compute_segment_local_coordinates()
-                soma = cell.CellRef.soma[0]
-                # soma position is the average of all its segment points
-                soma_global_position = np.array(all_seg_points[soma.name()]).mean(axis=0)
-                soma_local_position = np.array(local_seg_points[soma.name()]).mean(axis=0)
+    @classmethod
+    def apply_all_stimuli(cls, cell_manager):
+        """Apply all consolidated stimuli to their segments.
+        Computes segment displacements on the fly from cell geometry.
+        """
+        if not cls._instance:
+            return
+        for gid, es in cls._instance.stimList.items():
+            cell = cell_manager.get_cell(gid)
 
-                def local_to_global(pos, cell=cell, soma_local_position=soma_local_position):
-                    return cell.local_to_global_coord_mapping(
-                        np.vstack([soma_local_position, pos])
-                    )[1]
+            # Compute segment displacements from the ground point (soma barycenter)
+            all_seg_points = cell.compute_segment_global_coordinates()
+            local_seg_points = cell.compute_segment_local_coordinates()
+            soma = cell.CellRef.soma[0]
+            soma_global_position = np.array(all_seg_points[soma.name()]).mean(axis=0)
+            soma_local_position = np.array(local_seg_points[soma.name()]).mean(axis=0)
 
-                for sec_id, sc in enumerate(target_point_list.sclst):
-                    # skip sections not in this split
-                    if not sc.exists():
-                        continue
+            def local_to_global(pos, cell=cell, soma_local_position=soma_local_position):
+                return cell.local_to_global_coord_mapping(np.vstack([soma_local_position, pos]))[1]
+
+            segment_displacements = {}
+            for sec in cell.CellRef.all:
+                for seg in sec:
                     segment_position = (
-                        self.get_segment_position(
-                            all_seg_points[sc.sec.name()],
+                        cls.get_segment_position(
+                            all_seg_points[sec.name()],
                             soma_local_position,
-                            sc.sec,
-                            target_point_list.x[sec_id],
+                            sec,
+                            seg.x,
                             local_to_global,
                         )
-                        if "soma" not in sc.sec.name()
+                        if "soma" not in sec.name()
                         else soma_global_position
                     )
-                    # vector of displacement in x,y,z, convert from um to m
                     displacement_vec = (segment_position - soma_global_position) * 1e-6
-                    segment = sc.sec(target_point_list.x[sec_id])
-                    es.segment_displacements[segment] = displacement_vec
+                    segment_displacements[seg] = displacement_vec
 
-    @classmethod
-    def apply_all_stimuli(cls):
-        """Apply all consolidated stimuli to their segments"""
-        if cls._instance:
-            for es in cls._instance.stimList.values():
-                es.apply_segment_potentials()
+            es.apply_segment_potentials(segment_displacements)
 
     def parse_check_all_parameters(self, stim_info: dict):
         self.duration = float(stim_info["Duration"])  # duration [ms]

--- a/tests/unit-mpi/test_extracellular_stimulus.py
+++ b/tests/unit-mpi/test_extracellular_stimulus.py
@@ -114,5 +114,3 @@ def test_one_constant_field(create_tmp_simulation_config_file, mpi_ranks):
     npt.assert_allclose(rec_dend, REF_CONSTANT[gid], atol=1e-6)
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)
-
-    assert es.segment_displacements is None

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -100,8 +100,6 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)
 
-    n.clear_model()
-
 
 @pytest.mark.parametrize(
     "create_tmp_simulation_config_file",

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -373,9 +373,6 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
 
     assert all(sec.has_membrane("extracellular") for sec in cell.all)
 
-    assert es.efields is None
-    assert es.segment_displacements is None
-
     n.clear_model()
 
 

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -411,8 +411,6 @@ def test_two_fields(create_tmp_simulation_config_file):
 
     assert all(sec.has_membrane("extracellular") for sec in cell.all)
 
-    assert es.segment_displacements is None
-
 
 @pytest.mark.parametrize(
     "create_tmp_simulation_config_file",


### PR DESCRIPTION
## Context
Fix: #524

## Scope

Move displacement computation from add_new_stimuli into apply_all_stimuli, eliminating the intermediate segment_displacements dict on ElectrodeSource and the explicit cleanup() call. The displacement vectors now live as local variables scoped to the apply loop iteration.

The geometry computation (segment coordinates + displacements) was done once per stimList entry before, and it's still once per stimList entry now — just deferred from init time to apply time. stimList is already the union of all gids across stimulus blocks, so no work is duplicated.

## Testing

Internal refactoring: tests should be already in place and should not change

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
