### PR TITLE
Combine multiple extracellular electric field stimulus blocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,5 +123,5 @@ Copyright (c) 2005-2024 Blue Brain Project/EPFL
 Copyright (c) 2025-2026 Open Brain Institute
 
 .. substitutions
-.. |banner| image:: docs/img/neurodamus_banner_230701.png
+.. |banner| image:: docs/source/img/neurodamus_banner_230701.png
 

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -516,9 +516,7 @@ class ElectrodeSource:
             n_fields = len(self.efields)
             freq_vector = Nd.h.Vector(n_fields)
             phase_vector = Nd.h.Vector(n_fields)
-            x_vec = Nd.h.Vector(n_fields)
-            y_vec = Nd.h.Vector(n_fields)
-            z_vec = Nd.h.Vector(n_fields)
+            peak_potential_vec = Nd.h.Vector(n_fields)
             delay_vec = Nd.h.Vector(n_fields)
             duration_vec = Nd.h.Vector(n_fields)
             rup_vec = Nd.h.Vector(n_fields)
@@ -527,9 +525,12 @@ class ElectrodeSource:
             for i, field in enumerate(self.efields):
                 freq_vector.x[i] = field.frequency
                 phase_vector.x[i] = field.phase
-                x_vec.x[i] = field.ex * displacement[0]
-                y_vec.x[i] = field.ey * displacement[1]
-                z_vec.x[i] = field.ez * displacement[2]
+                # dot product E·d in V, converted to mV (* 1e3)
+                peak_potential_vec.x[i] = 1e3 * (
+                    field.ex * displacement[0]
+                    + field.ey * displacement[1]
+                    + field.ez * displacement[2]
+                )
                 delay_vec.x[i] = field.delay
                 duration_vec.x[i] = field.duration
                 rup_vec.x[i] = field.ramp_up_time
@@ -542,9 +543,7 @@ class ElectrodeSource:
                 duration_vec,
                 rup_vec,
                 rdown_vec,
-                x_vec,
-                y_vec,
-                z_vec,
+                peak_potential_vec,
                 phase_vector,
                 freq_vector,
             )

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -1,6 +1,7 @@
 """Stimuli sources. inc current and conductance sources which can be attached to cells"""
 
 import logging
+from dataclasses import dataclass
 
 from .configuration import ConfigurationError
 from .random import RNG, gamma
@@ -492,40 +493,45 @@ class ConductanceSource(SignalSource):
         )
 
 
-class ElectrodeSource:
-    """Constructs an extracellular potential field as the sum of multiple user-defined e-fields,
-    and applies the resulting signal to the segment's e_extracellular.
+@dataclass
+class EField:
+    """Dataclass for electric field definition, currently cosinusoid"""
 
-    Args:
-        base_amp: baseline amplitude when signal is inactive
-        delay: start time delay in ms
-        duration: duration of the signal, not including ramp up and ramp down
-        fields: list of user-defined electric field components (e.g. cosinuoid fields)
-        duration: duration of the signal, not including ramp up and ramp down.
-        ramp_up_time: duration during which the signal amplitude ramps up linearly from 0, in ms
-        ramp_down_time: duration during which the signal amplitude ramps down linearly to 0, in ms
+    ex: float  # Peak amplitude of x-direction in in V/m
+    ey: float  # Peak amplitude of y-direction in in V/m
+    ez: float  # Peak amplitude of z-direction in in V/m
+    frequency: float  # Frequency of the cosinusoid wave in Hz
+    phase: float  # Phase of the cosinusoid, in radians
+    duration: float  # duration of the signal, not including ramp up and ramp down in ms
+    delay: float  # start time delay in ms
+    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
+    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
+
+
+class ElectrodeSource:
+    """Manages extracellular electric field stimulation for a single cell
+    and applies to every segment.extracellular._ref_e via EFieldIntegrator mechanism.
+    EFieldIntegrator computes the potential at every time step as the sum of one or more e-fields,
+    each defined by direction, frequency, phase, delay, ramp up and ramp down,
     """
 
-    def __init__(self, base_amp, delay, duration, fields, ramp_up_time, ramp_down_time, dt):
-        self.time_vec = Nd.h.Vector()  # Time points for stimulus waveform
-        self._cur_t = 0
-        self._base_amp = base_amp
-        self._delay = delay
-        self.fields = fields
-        self.duration = duration
-        self.dt = dt
-        self.ramp_up_time = ramp_up_time
-        self.ramp_down_time = ramp_down_time
+    def __init__(self, delay, duration, fields, ramp_up_time, ramp_down_time):
         self.segment_displacements = {}  # {segment: displacement vectors in x/y/z w.r.t ground}
-        self.segment_efield_integrators = []
-
-    def delay(self, duration):
-        """Increments the ref time so that the next created signal is delayed"""
-        # NOTE: We rely on the fact that Neuron allows "instantaneous" changes
-        # and made all signal shapes return to base_amp. Therefore delay() doesn't
-        # need to introduce any point to avoid interpolation.
-        self._cur_t += duration
-        return self
+        self.segment_efield_integrators = []  # list of EFieldIntegrator attached to segments
+        self.fields = [
+            EField(
+                ex=f["Ex"],
+                ey=f["Ey"],
+                ez=f["Ez"],
+                frequency=f["Frequency"],
+                phase=f["Phase"],
+                duration=duration,
+                delay=delay,
+                ramp_up_time=ramp_up_time,
+                ramp_down_time=ramp_down_time,
+            )
+            for f in fields
+        ]  # list of EFields objects
 
     def apply_segment_potentials(self):
         """Apply potentials to segment.extracellular._ref_e"""
@@ -541,20 +547,20 @@ class ElectrodeSource:
             y_vec = Nd.h.Vector(len(self.fields))
             z_vec = Nd.h.Vector(len(self.fields))
             for i, field in enumerate(self.fields):
-                freq_vector.x[i] = field["Frequency"]
-                phase_vector.x[i] = field["Phase"]
-                x_vec.x[i] = field["Ex"]
-                y_vec.x[i] = field["Ey"]
-                z_vec.x[i] = field["Ez"]
+                freq_vector.x[i] = field.frequency
+                phase_vector.x[i] = field.phase
+                x_vec.x[i] = field.ex
+                y_vec.x[i] = field.ey
+                z_vec.x[i] = field.ez
             efi = Nd.h.EFieldIntegrator(segment)
             Nd.h.setpointer(segment.extracellular._ref_e, "e_ext", efi)
             efi.enabled = 1
             efi.set_displacement(Nd.h.Vector(displacement))
             efi.add_electrode_source(
-                self._delay,
-                self.duration,
-                self.ramp_up_time,
-                self.ramp_down_time,
+                self.fields[0].delay,
+                self.fields[0].duration,
+                self.fields[0].ramp_up_time,
+                self.fields[0].ramp_down_time,
                 x_vec,
                 y_vec,
                 z_vec,

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -1,10 +1,10 @@
 """Stimuli sources. inc current and conductance sources which can be attached to cells"""
 
 import logging
-from dataclasses import dataclass
 
 from .random import RNG, gamma
 from neurodamus.core import NeuronWrapper as Nd
+from neurodamus.io.sonata_config import EField
 
 
 class SignalSource:
@@ -490,21 +490,6 @@ class ConductanceSource(SignalSource):
             self._reversal,
             represents_physical_electrode=self._represents_physical_electrode,
         )
-
-
-@dataclass
-class EField:
-    """Dataclass for electric field definition, currently cosinusoid"""
-
-    ex: float  # Peak amplitude of x-direction in in V/m
-    ey: float  # Peak amplitude of y-direction in in V/m
-    ez: float  # Peak amplitude of z-direction in in V/m
-    frequency: float  # Frequency of the cosinusoid wave in Hz
-    phase: float  # Phase of the cosinusoid, in radians
-    duration: float  # duration of the signal, not including ramp up and ramp down in ms
-    delay: float  # start time delay in ms
-    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
-    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
 
 
 class ElectrodeSource:

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -555,9 +555,9 @@ class ElectrodeSource:
             for i, field in enumerate(self.fields):
                 freq_vector.x[i] = field.frequency
                 phase_vector.x[i] = field.phase
-                x_vec.x[i] = field.ex
-                y_vec.x[i] = field.ey
-                z_vec.x[i] = field.ez
+                x_vec.x[i] = field.ex * displacement[0]
+                y_vec.x[i] = field.ey * displacement[1]
+                z_vec.x[i] = field.ez * displacement[2]
                 delay_vec.x[i] = field.delay
                 duration_vec.x[i] = field.duration
                 rup_vec.x[i] = field.ramp_up_time
@@ -565,7 +565,6 @@ class ElectrodeSource:
             efi = Nd.h.EFieldIntegrator(segment)
             Nd.h.setpointer(segment.extracellular._ref_e, "e_ext", efi)
             efi.enabled = 1
-            efi.set_displacement(Nd.h.Vector(displacement))
             efi.add_electrode_source(
                 delay_vec,
                 duration_vec,

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -3,7 +3,6 @@
 import logging
 from dataclasses import dataclass
 
-from .configuration import ConfigurationError
 from .random import RNG, gamma
 from neurodamus.core import NeuronWrapper as Nd
 
@@ -517,7 +516,7 @@ class ElectrodeSource:
 
     def __init__(self, delay, duration, fields, ramp_up_time, ramp_down_time):
         self.segment_displacements = {}  # {segment: displacement vectors in x/y/z w.r.t ground}
-        self.segment_efield_integrators = []  # list of EFieldIntegrator attached to segments
+        self.segment_efield_integrators = []  # list of EFieldIntegrator mechs attached to segments
         self.fields = [
             EField(
                 ex=f["Ex"],
@@ -582,11 +581,9 @@ class ElectrodeSource:
 
     def cleanup(self):
         """Clear unused list variable to free memory"""
-        self.efields = None
         self.segment_displacements = None
 
     def __iadd__(self, other):
         """Combined with another ElectrodeSource object"""
-        logging.error("Multiple ElectrodeSource not supported with nmodl")
-        raise ConfigurationError("Support for multiple ElectrodeSources pending")
-        # return self
+        self.fields.extend(other.fields)
+        return self

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -1,6 +1,7 @@
 """Stimuli sources. inc current and conductance sources which can be attached to cells"""
 
 import logging
+from dataclasses import dataclass
 
 from .random import RNG, gamma
 from neurodamus.core import NeuronWrapper as Nd
@@ -491,14 +492,29 @@ class ConductanceSource(SignalSource):
         )
 
 
+@dataclass
+class EField:
+    """Dataclass for electric field definition, currently cosinusoid"""
+
+    ex: float  # Peak amplitude of x-direction in in V/m
+    ey: float  # Peak amplitude of y-direction in in V/m
+    ez: float  # Peak amplitude of z-direction in in V/m
+    frequency: float  # Frequency of the cosinusoid wave in Hz
+    phase: float  # Phase of the cosinusoid, in radians
+    duration: float  # duration of the signal, not including ramp up and ramp down in ms
+    delay: float  # start time delay in ms
+    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
+    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
+
+
 class ElectrodeSource:
     """Manages extracellular electric field stimulation for a single cell
     and applies to every segment.extracellular._ref_e via EFieldIntegrator mechanism.
     EFieldIntegrator computes the potential at every time step as the sum of multiple e-fields,
-    each defined by peak amplitude (Ex,Ey,Ez), frequency, phase, delay, ramp up and ramp down.
+    each defined by peak amplitudes (Ex,Ey,Ez), frequency, phase, delay, ramp up and ramp down.
     """
 
-    def __init__(self, efields):
+    def __init__(self, efields: list[EField]):
         self.segment_displacements = {}  # {segment object: displacement vec in x/y/z w.r.t ground}
         self.segment_efield_integrators = []  # list of EFieldIntegrator mechs attached to segments
         self.efields = efields  # list of EFields objects

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -516,8 +516,9 @@ class ElectrodeSource:
 
     def __init__(self, efields: list[EField]):
         self.segment_displacements = {}  # {segment object: displacement vec in x/y/z w.r.t ground}
-        self.segment_efield_integrators = []  # list of EFieldIntegrator mechs attached to segments
-        self.efields = efields  # list of EFields objects
+        # list of EFieldIntegrator mechs attached to segments, required to avoid garbage collection
+        self.segment_efield_integrators = []
+        self.efields = efields
 
     def apply_segment_potentials(self):
         """Apply potentials to segment.extracellular._ref_e"""

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -541,26 +541,36 @@ class ElectrodeSource:
                 section.insert("extracellular")
 
             # convert field data into multiple hoc vectors
-            freq_vector = Nd.h.Vector(len(self.fields))
-            phase_vector = Nd.h.Vector(len(self.fields))
-            x_vec = Nd.h.Vector(len(self.fields))
-            y_vec = Nd.h.Vector(len(self.fields))
-            z_vec = Nd.h.Vector(len(self.fields))
+            n_fields = len(self.fields)
+            freq_vector = Nd.h.Vector(n_fields)
+            phase_vector = Nd.h.Vector(n_fields)
+            x_vec = Nd.h.Vector(n_fields)
+            y_vec = Nd.h.Vector(n_fields)
+            z_vec = Nd.h.Vector(n_fields)
+            delay_vec = Nd.h.Vector(n_fields)
+            duration_vec = Nd.h.Vector(n_fields)
+            rup_vec = Nd.h.Vector(n_fields)
+            rdown_vec = Nd.h.Vector(n_fields)
+
             for i, field in enumerate(self.fields):
                 freq_vector.x[i] = field.frequency
                 phase_vector.x[i] = field.phase
                 x_vec.x[i] = field.ex
                 y_vec.x[i] = field.ey
                 z_vec.x[i] = field.ez
+                delay_vec.x[i] = field.delay
+                duration_vec.x[i] = field.duration
+                rup_vec.x[i] = field.ramp_up_time
+                rdown_vec.x[i] = field.ramp_down_time
             efi = Nd.h.EFieldIntegrator(segment)
             Nd.h.setpointer(segment.extracellular._ref_e, "e_ext", efi)
             efi.enabled = 1
             efi.set_displacement(Nd.h.Vector(displacement))
             efi.add_electrode_source(
-                self.fields[0].delay,
-                self.fields[0].duration,
-                self.fields[0].ramp_up_time,
-                self.fields[0].ramp_down_time,
+                delay_vec,
+                duration_vec,
+                rup_vec,
+                rdown_vec,
                 x_vec,
                 y_vec,
                 z_vec,

--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -1,7 +1,6 @@
 """Stimuli sources. inc current and conductance sources which can be attached to cells"""
 
 import logging
-from dataclasses import dataclass
 
 from .random import RNG, gamma
 from neurodamus.core import NeuronWrapper as Nd
@@ -492,45 +491,17 @@ class ConductanceSource(SignalSource):
         )
 
 
-@dataclass
-class EField:
-    """Dataclass for electric field definition, currently cosinusoid"""
-
-    ex: float  # Peak amplitude of x-direction in in V/m
-    ey: float  # Peak amplitude of y-direction in in V/m
-    ez: float  # Peak amplitude of z-direction in in V/m
-    frequency: float  # Frequency of the cosinusoid wave in Hz
-    phase: float  # Phase of the cosinusoid, in radians
-    duration: float  # duration of the signal, not including ramp up and ramp down in ms
-    delay: float  # start time delay in ms
-    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
-    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
-
-
 class ElectrodeSource:
     """Manages extracellular electric field stimulation for a single cell
     and applies to every segment.extracellular._ref_e via EFieldIntegrator mechanism.
-    EFieldIntegrator computes the potential at every time step as the sum of one or more e-fields,
-    each defined by direction, frequency, phase, delay, ramp up and ramp down,
+    EFieldIntegrator computes the potential at every time step as the sum of multiple e-fields,
+    each defined by peak amplitude (Ex,Ey,Ez), frequency, phase, delay, ramp up and ramp down.
     """
 
-    def __init__(self, delay, duration, fields, ramp_up_time, ramp_down_time):
-        self.segment_displacements = {}  # {segment: displacement vectors in x/y/z w.r.t ground}
+    def __init__(self, efields):
+        self.segment_displacements = {}  # {segment object: displacement vec in x/y/z w.r.t ground}
         self.segment_efield_integrators = []  # list of EFieldIntegrator mechs attached to segments
-        self.fields = [
-            EField(
-                ex=f["Ex"],
-                ey=f["Ey"],
-                ez=f["Ez"],
-                frequency=f["Frequency"],
-                phase=f["Phase"],
-                duration=duration,
-                delay=delay,
-                ramp_up_time=ramp_up_time,
-                ramp_down_time=ramp_down_time,
-            )
-            for f in fields
-        ]  # list of EFields objects
+        self.efields = efields  # list of EFields objects
 
     def apply_segment_potentials(self):
         """Apply potentials to segment.extracellular._ref_e"""
@@ -540,7 +511,7 @@ class ElectrodeSource:
                 section.insert("extracellular")
 
             # convert field data into multiple hoc vectors
-            n_fields = len(self.fields)
+            n_fields = len(self.efields)
             freq_vector = Nd.h.Vector(n_fields)
             phase_vector = Nd.h.Vector(n_fields)
             x_vec = Nd.h.Vector(n_fields)
@@ -551,7 +522,7 @@ class ElectrodeSource:
             rup_vec = Nd.h.Vector(n_fields)
             rdown_vec = Nd.h.Vector(n_fields)
 
-            for i, field in enumerate(self.fields):
+            for i, field in enumerate(self.efields):
                 freq_vector.x[i] = field.frequency
                 phase_vector.x[i] = field.phase
                 x_vec.x[i] = field.ex * displacement[0]
@@ -585,5 +556,5 @@ class ElectrodeSource:
 
     def __iadd__(self, other):
         """Combined with another ElectrodeSource object"""
-        self.fields.extend(other.fields)
+        self.efields.extend(other.efields)
         return self

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -2,7 +2,7 @@ NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
     POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
-    RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned pointer reference
+    RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
 }
 
 PARAMETER {
@@ -30,6 +30,22 @@ INITIAL {
     if( enabled ) {
         e_ext = 0
     }
+
+VERBATIM
+#ifndef CORENEURON_BUILD
+    if( !_p_X ) {
+        _p_X = vector_new1(0);
+        _p_Y = vector_new1(0);
+        _p_Z = vector_new1(0);
+        _p_phase = vector_new1(0);
+        _p_frequency = vector_new1(0);
+        _p_delay = vector_new1(0);
+        _p_duration = vector_new1(0);
+        _p_ramp_up = vector_new1(0);
+        _p_ramp_down = vector_new1(0);
+    }
+#endif
+ENDVERBATIM
 }
 
 PROCEDURE add_electrode_source() {
@@ -87,15 +103,11 @@ ENDVERBATIM
 FUNCTION get_potential_amplitude(i) {
     : get potential amplitude for ith electrod field, in mV
 VERBATIM
-    if (!_p_X) {
-        _lget_potential_amplitude = 0;
-    } else {
-        int idx = (int)_li;
-        auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-        auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-        auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-        _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
-    }
+    int idx = (int)_li;
+    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
 ENDVERBATIM
 }
 
@@ -109,38 +121,38 @@ VERBATIM
     double cur_delay, cur_duration, cur_ramp_up, cur_ramp_down;
     _lefield_accum = 0;
 
-    if (enabled) {
-        auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-        auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-        auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-        auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
-        auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
-        auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
-        auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
-        auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
-        auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
-        size = vector_capacity(vX);
+    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
+    auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+    auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
+    auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
+    auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
+    auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
+    size = vector_capacity(vX);
 
-        for( i=0; i<size; i++ ) {
-            cur_delay = vector_vec(vdelay)[i];
-            cur_duration = vector_vec(vduration)[i];
-            cur_ramp_up = vector_vec(vramp_up)[i];
-            cur_ramp_down = vector_vec(vramp_down)[i];
-            if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
-                if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
-                    ramp_factor = (t-cur_delay) / cur_ramp_up;
-                }
-                if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
-                    ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
-                }
-                double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
-                _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
+    for( i=0; i<size; i++ ) {
+        cur_delay = vector_vec(vdelay)[i];
+        cur_duration = vector_vec(vduration)[i];
+        cur_ramp_up = vector_vec(vramp_up)[i];
+        cur_ramp_down = vector_vec(vramp_down)[i];
+        if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+            if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
+                ramp_factor = (t-cur_delay) / cur_ramp_up;
             }
+            if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+                ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
+            }
+            double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
+            _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
         }
-        e_ext = _lefield_accum;
     }
 #endif
 ENDVERBATIM
+    if( enabled ) {
+        e_ext = efield_accum
+    }
 }
 
 : currently, extracellular stimulus is not supported by coreneuron, so will

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -85,12 +85,13 @@ ENDVERBATIM
 }
 
 FUNCTION get_potential_amplitude(i) {
+    : get potential amplitude for ith electrod field, in V
 VERBATIM
     int idx = (int)_li;
     auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
     auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
     auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-    _lget_potential_amplitude = vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx];
+    _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
 ENDVERBATIM
 }
 
@@ -128,7 +129,7 @@ VERBATIM
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
             double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
-	        _lefield_accum += 1e3 * ramp_factor * get_potential_amplitude(i) * wavefactor;
+	        _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
         }
     }
 #endif

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -1,9 +1,7 @@
 NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
-    :POINTER delay, duration, ramp_up, ramp_down : TODO: add nfields vector and vectors will have size = nElectrodeSource
-    POINTER phase, frequency, X, Y, Z           : TODO: will have size = sum(nFields for each ElectrodeSource)
-    RANGE delay, duration, ramp_up, ramp_down
+    POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
     RANGE displacementX, displacementY, displacementZ
     RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
 }
@@ -51,16 +49,14 @@ ENDVERBATIM
 
 PROCEDURE add_electrode_source() {
     : receive data elements for an ElectrodeSource
-    : delay, duration, ramp_up_time, ramp_down_time
-    : vectors for n fields: x, y, z, freq, phase,
+    : vectors for n fields: delay, duration, ramp_up_time, ramp_down_time, x, y, z, freq, phase,
 
 VERBATIM
 #ifndef CORENEURON_BUILD
-    delay = *getarg(1);
-    duration = *getarg(2);
-    ramp_up = *getarg(3);
-    ramp_down = *getarg(4);
-
+    auto* argdelay = vector_arg(1);
+    auto* argduration = vector_arg(2);
+    auto* argramp_up = vector_arg(3);
+    auto* argramp_down = vector_arg(4);
     auto* argX = vector_arg(5);
     auto* argY = vector_arg(6);
     auto* argZ = vector_arg(7);
@@ -68,29 +64,36 @@ VERBATIM
     auto* argfreq = vector_arg(9);
 
     int size = vector_capacity(argX);
-    if( _p_phase != nullptr ) {
-        fprintf( stderr, "support for multiple ElectrodeSource info not implemented yet\n" );
-        //TODO: vector_resize( vphase, vector_capacity(vec) );
-    } else {
-        _p_X = vector_new1(size);
-        _p_Y = vector_new1(size);
-        _p_Z = vector_new1(size);
-        _p_phase = vector_new1(size);
-        _p_frequency = vector_new1(size);
+    _p_X = vector_new1(size);
+    _p_Y = vector_new1(size);
+    _p_Z = vector_new1(size);
+    _p_phase = vector_new1(size);
+    _p_frequency = vector_new1(size);
+    _p_delay = vector_new1(size);
+    _p_duration = vector_new1(size);
+    _p_ramp_up = vector_new1(size);
+    _p_ramp_down = vector_new1(size);
 
-        auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-        auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-        auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-        auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
-        auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
+    auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+    auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
+    auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
+    auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
+    auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
 
-        for( int i=0; i<size; i++ ) {
-            vector_vec(vX)[i] = displacementX * vector_vec(argX)[i];
-            vector_vec(vY)[i] = displacementY * vector_vec(argY)[i];
-            vector_vec(vZ)[i] = displacementZ * vector_vec(argZ)[i];
-            vector_vec(vphase)[i] = vector_vec(argphase)[i];
-            vector_vec(vfreq)[i] = vector_vec(argfreq)[i];
-        }
+    for( int i=0; i<size; i++ ) {
+        vector_vec(vX)[i] = displacementX * vector_vec(argX)[i];
+        vector_vec(vY)[i] = displacementY * vector_vec(argY)[i];
+        vector_vec(vZ)[i] = displacementZ * vector_vec(argZ)[i];
+        vector_vec(vphase)[i] = vector_vec(argphase)[i];
+        vector_vec(vfreq)[i] = vector_vec(argfreq)[i];
+        vector_vec(vdelay)[i] = vector_vec(argdelay)[i];
+        vector_vec(vduration)[i] = vector_vec(argduration)[i];
+        vector_vec(vramp_up)[i] = vector_vec(argramp_up)[i];
+        vector_vec(vramp_down)[i] = vector_vec(argramp_down)[i];
     }
 #endif
 ENDVERBATIM
@@ -106,29 +109,35 @@ VERBATIM
 #ifndef CORENEURON_BUILD
     int i, size;
     double ramp_factor=1;
+    double cur_delay, cur_duration, cur_ramp_up, cur_ramp_down;
     _lefield_accum = 0;
 
-/* TODO: Adapting to multiple ElectrodeSources */
-    if( delay < t && t < delay+duration+ramp_up+ramp_down ) {
-       auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-       auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-       auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-       auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
-       auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
+    auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+    auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
+    auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
+    auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
+    auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
+    size = vector_capacity(vX);
 
-       // TODO: if in a ramp up/down window, then scale further
-       if( delay < t && t < delay+ramp_up ) {
-           ramp_factor = (t-delay) / ramp_up;
-       }
-       if( delay+ramp_up+duration < t && t < delay+duration+ramp_up+ramp_down ) {
-           ramp_factor = 1 - (t-(delay+ramp_up+duration)) / ramp_down;
-       }
-
-       size = vector_capacity(vX);
-       for( i=0; i<size; i++ ) {
-           double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-delay) + vector_vec(vphase)[i] );
-	   _lefield_accum += 1e3 * ramp_factor * (vector_vec(vX)[i] * wavefactor + vector_vec(vY)[i] * wavefactor + vector_vec(vZ)[i] * wavefactor);
-       }
+    for( i=0; i<size; i++ ) {
+        cur_delay = vector_vec(vdelay)[i];
+        cur_duration = vector_vec(vduration)[i];
+        cur_ramp_up = vector_vec(vramp_up)[i];
+        cur_ramp_down = vector_vec(vramp_down)[i];
+        if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+            if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
+                ramp_factor = (t-cur_delay) / cur_ramp_up;
+            }
+            if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+                ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
+            }
+            double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
+	        _lefield_accum += 1e3 * ramp_factor * (vector_vec(vX)[i] * wavefactor + vector_vec(vY)[i] * wavefactor + vector_vec(vZ)[i] * wavefactor);
+        }
     }
 #endif
 ENDVERBATIM

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -1,7 +1,7 @@
 NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
-    POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
+    POINTER phase, frequency, peak_potential, delay, duration, ramp_up, ramp_down
     RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
 }
 
@@ -20,9 +20,7 @@ ASSIGNED {
     ramp_down
     phase
     frequency
-    X
-    Y
-    Z
+    peak_potential
     enabled
 }
 
@@ -33,10 +31,8 @@ INITIAL {
 
 VERBATIM
 #ifndef CORENEURON_BUILD
-    if( !_p_X ) {
-        _p_X = vector_new1(0);
-        _p_Y = vector_new1(0);
-        _p_Z = vector_new1(0);
+    if( !_p_peak_potential ) {
+        _p_peak_potential = vector_new1(0);
         _p_phase = vector_new1(0);
         _p_frequency = vector_new1(0);
         _p_delay = vector_new1(0);
@@ -50,7 +46,7 @@ ENDVERBATIM
 
 PROCEDURE add_electrode_source() {
     : receive data elements for an ElectrodeSource
-    : vectors for n fields: delay, duration, ramp_up_time, ramp_down_time, x, y, z, freq, phase,
+    : vectors for n fields: delay, duration, ramp_up_time, ramp_down_time, peak_potential, freq, phase
 
 VERBATIM
 #ifndef CORENEURON_BUILD
@@ -58,16 +54,12 @@ VERBATIM
     auto* argduration = vector_arg(2);
     auto* argramp_up = vector_arg(3);
     auto* argramp_down = vector_arg(4);
-    auto* argX = vector_arg(5);
-    auto* argY = vector_arg(6);
-    auto* argZ = vector_arg(7);
-    auto* argphase = vector_arg(8);
-    auto* argfreq = vector_arg(9);
+    auto* argpeak_potential = vector_arg(5);
+    auto* argphase = vector_arg(6);
+    auto* argfreq = vector_arg(7);
 
-    int size = vector_capacity(argX);
-    _p_X = vector_new1(size);
-    _p_Y = vector_new1(size);
-    _p_Z = vector_new1(size);
+    int size = vector_capacity(argpeak_potential);
+    _p_peak_potential = vector_new1(size);
     _p_phase = vector_new1(size);
     _p_frequency = vector_new1(size);
     _p_delay = vector_new1(size);
@@ -75,9 +67,7 @@ VERBATIM
     _p_ramp_up = vector_new1(size);
     _p_ramp_down = vector_new1(size);
 
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    auto *vpeak = *reinterpret_cast<IvocVect**>(&_p_peak_potential);
     auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
     auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
     auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
@@ -86,9 +76,7 @@ VERBATIM
     auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
 
     for( int i=0; i<size; i++ ) {
-        vector_vec(vX)[i] = vector_vec(argX)[i];
-        vector_vec(vY)[i] = vector_vec(argY)[i];
-        vector_vec(vZ)[i] = vector_vec(argZ)[i];
+        vector_vec(vpeak)[i] = vector_vec(argpeak_potential)[i];
         vector_vec(vphase)[i] = vector_vec(argphase)[i];
         vector_vec(vfreq)[i] = vector_vec(argfreq)[i];
         vector_vec(vdelay)[i] = vector_vec(argdelay)[i];
@@ -100,14 +88,13 @@ VERBATIM
 ENDVERBATIM
 }
 
-FUNCTION get_potential_amplitude(i) {
-    : get potential amplitude for ith eletric field, in mV
+FUNCTION get_peak_potential(i) {
+    : get peak potential for ith electric field, in mV
+    : this is the dot product E dot d (field * displacement) pre-computed on the Python side
 VERBATIM
     int idx = (int)_li;
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-    _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
+    auto *vpeak = *reinterpret_cast<IvocVect**>(&_p_peak_potential);
+    _lget_peak_potential = vector_vec(vpeak)[idx];
 ENDVERBATIM
 }
 
@@ -139,7 +126,7 @@ VERBATIM
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
             double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i]);
-            _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
+            _lefield_accum += ramp_factor * get_peak_potential(i) * wavefactor;
         }
     }
 #endif
@@ -151,4 +138,3 @@ ENDVERBATIM
 
 : currently, extracellular stimulus is not supported by coreneuron, so will
 : skip using BBCOREPOINTER and bbcore_write/bbcore_read
-

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -122,7 +122,7 @@ VERBATIM
             if( t < cur_delay + cur_ramp_up ) {
                 ramp_factor = (t-cur_delay) / cur_ramp_up;
             }
-            if( cur_delay + cur_ramp_up + cur_duration < t ) {
+            else if( t > (cur_delay + cur_ramp_up + cur_duration) ) {
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
             double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i]);

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -101,7 +101,7 @@ ENDVERBATIM
 }
 
 FUNCTION get_potential_amplitude(i) {
-    : get potential amplitude for ith electrod field, in mV
+    : get potential amplitude for ith eletric field, in mV
 VERBATIM
     int idx = (int)_li;
     auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
@@ -131,7 +131,7 @@ VERBATIM
     size = vector_capacity(vX);
 
     for( i=0; i<size; i++ ) {
-        double ramp_factor=1;
+        double ramp_factor = 1;
         double cur_delay = vector_vec(vdelay)[i];
         double cur_duration = vector_vec(vduration)[i];
         double cur_ramp_up = vector_vec(vramp_up)[i];

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -117,8 +117,6 @@ BEFORE BREAKPOINT {
 VERBATIM
 #ifndef CORENEURON_BUILD
     int i, size;
-    double ramp_factor=1;
-    double cur_delay, cur_duration, cur_ramp_up, cur_ramp_down;
     _lefield_accum = 0;
 
     auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
@@ -133,10 +131,11 @@ VERBATIM
     size = vector_capacity(vX);
 
     for( i=0; i<size; i++ ) {
-        cur_delay = vector_vec(vdelay)[i];
-        cur_duration = vector_vec(vduration)[i];
-        cur_ramp_up = vector_vec(vramp_up)[i];
-        cur_ramp_down = vector_vec(vramp_down)[i];
+        double ramp_factor=1;
+        double cur_delay = vector_vec(vdelay)[i];
+        double cur_duration = vector_vec(vduration)[i];
+        double cur_ramp_up = vector_vec(vramp_up)[i];
+        double cur_ramp_down = vector_vec(vramp_down)[i];
         if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
             if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
                 ramp_factor = (t-cur_delay) / cur_ramp_up;

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -116,34 +116,29 @@ BEFORE BREAKPOINT {
 
 VERBATIM
 #ifndef CORENEURON_BUILD
-    int i, size;
     _lefield_accum = 0;
 
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
     auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
     auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
     auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
     auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
     auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
     auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
-    size = vector_capacity(vX);
 
-    for( i=0; i<size; i++ ) {
+    for( int i=0; i < vector_capacity(vdelay); i++ ) {
         double ramp_factor = 1;
         double cur_delay = vector_vec(vdelay)[i];
         double cur_duration = vector_vec(vduration)[i];
         double cur_ramp_up = vector_vec(vramp_up)[i];
         double cur_ramp_down = vector_vec(vramp_down)[i];
         if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
-            if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
+            if( t < cur_delay + cur_ramp_up ) {
                 ramp_factor = (t-cur_delay) / cur_ramp_up;
             }
-            if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+            if( cur_delay + cur_ramp_up + cur_duration < t ) {
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
-            double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
+            double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i]);
             _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
         }
     }

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -2,7 +2,6 @@ NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
     POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
-    RANGE displacementX, displacementY, displacementZ
     RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
 }
 
@@ -24,9 +23,6 @@ ASSIGNED {
     X
     Y
     Z
-    displacementX
-    displacementY
-    displacementZ
     enabled
 }
 
@@ -34,17 +30,6 @@ INITIAL {
     if( enabled ) {
         e_ext = 0
     }
-}
-
-PROCEDURE set_displacement() {
-VERBATIM
-#ifndef CORENEURON_BUILD
-    auto* argdisp = vector_arg(1);
-    displacementX = vector_vec(argdisp)[0];
-    displacementY = vector_vec(argdisp)[1];
-    displacementZ = vector_vec(argdisp)[2];
-#endif
-ENDVERBATIM
 }
 
 PROCEDURE add_electrode_source() {
@@ -85,9 +70,9 @@ VERBATIM
     auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
 
     for( int i=0; i<size; i++ ) {
-        vector_vec(vX)[i] = displacementX * vector_vec(argX)[i];
-        vector_vec(vY)[i] = displacementY * vector_vec(argY)[i];
-        vector_vec(vZ)[i] = displacementZ * vector_vec(argZ)[i];
+        vector_vec(vX)[i] = vector_vec(argX)[i];
+        vector_vec(vY)[i] = vector_vec(argY)[i];
+        vector_vec(vZ)[i] = vector_vec(argZ)[i];
         vector_vec(vphase)[i] = vector_vec(argphase)[i];
         vector_vec(vfreq)[i] = vector_vec(argfreq)[i];
         vector_vec(vdelay)[i] = vector_vec(argdelay)[i];
@@ -99,12 +84,19 @@ VERBATIM
 ENDVERBATIM
 }
 
+FUNCTION get_potential_amplitude(i) {
+VERBATIM
+    int idx = (int)_li;
+    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    _lget_potential_amplitude = vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx];
+ENDVERBATIM
+}
+
 BEFORE BREAKPOINT {
     LOCAL efield_accum
 
-    : for each electrode source (pending)
-    :    for each field
-    :       in time window? compute contribution factor and apply to segment's e_ref via pointer
 VERBATIM
 #ifndef CORENEURON_BUILD
     int i, size;
@@ -136,7 +128,7 @@ VERBATIM
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
             double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
-	        _lefield_accum += 1e3 * ramp_factor * (vector_vec(vX)[i] * wavefactor + vector_vec(vY)[i] * wavefactor + vector_vec(vZ)[i] * wavefactor);
+	        _lefield_accum += 1e3 * ramp_factor * get_potential_amplitude(i) * wavefactor;
         }
     }
 #endif

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -2,7 +2,7 @@ NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
     POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
-    RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
+    RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned pointer reference
 }
 
 PARAMETER {
@@ -85,13 +85,17 @@ ENDVERBATIM
 }
 
 FUNCTION get_potential_amplitude(i) {
-    : get potential amplitude for ith electrod field, in V
+    : get potential amplitude for ith electrod field, in mV
 VERBATIM
-    int idx = (int)_li;
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-    _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
+    if (!_p_X) {
+        _lget_potential_amplitude = 0;
+    } else {
+        int idx = (int)_li;
+        auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+        auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+        auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+        _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
+    }
 ENDVERBATIM
 }
 
@@ -105,38 +109,38 @@ VERBATIM
     double cur_delay, cur_duration, cur_ramp_up, cur_ramp_down;
     _lefield_accum = 0;
 
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-    auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
-    auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
-    auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
-    auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
-    auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
-    auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
-    size = vector_capacity(vX);
+    if (enabled) {
+        auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
+        auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
+        auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+        auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
+        auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
+        auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
+        auto *vduration = *reinterpret_cast<IvocVect**>(&_p_duration);
+        auto *vramp_up = *reinterpret_cast<IvocVect**>(&_p_ramp_up);
+        auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
+        size = vector_capacity(vX);
 
-    for( i=0; i<size; i++ ) {
-        cur_delay = vector_vec(vdelay)[i];
-        cur_duration = vector_vec(vduration)[i];
-        cur_ramp_up = vector_vec(vramp_up)[i];
-        cur_ramp_down = vector_vec(vramp_down)[i];
-        if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
-            if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
-                ramp_factor = (t-cur_delay) / cur_ramp_up;
+        for( i=0; i<size; i++ ) {
+            cur_delay = vector_vec(vdelay)[i];
+            cur_duration = vector_vec(vduration)[i];
+            cur_ramp_up = vector_vec(vramp_up)[i];
+            cur_ramp_down = vector_vec(vramp_down)[i];
+            if( cur_delay < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+                if( cur_delay < t && t < cur_delay + cur_ramp_up ) {
+                    ramp_factor = (t-cur_delay) / cur_ramp_up;
+                }
+                if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
+                    ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
+                }
+                double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
+                _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
             }
-            if( cur_delay + cur_ramp_up + cur_duration < t && t < cur_delay + cur_duration + cur_ramp_up + cur_ramp_down ) {
-                ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
-            }
-            double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i] );
-	        _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
         }
+        e_ext = _lefield_accum;
     }
 #endif
 ENDVERBATIM
-    if( enabled ) {
-        e_ext = efield_accum
-    }
 }
 
 : currently, extracellular stimulus is not supported by coreneuron, so will

--- a/neurodamus/io/sonata_config.py
+++ b/neurodamus/io/sonata_config.py
@@ -88,6 +88,21 @@ class RunConfig:
     restore: str | None = None  # set in configuration.py
 
 
+@dataclass
+class EField:
+    """Dataclass for electric field definition, currently cosinusoid"""
+
+    ex: float  # Peak amplitude of x-direction in in V/m
+    ey: float  # Peak amplitude of y-direction in in V/m
+    ez: float  # Peak amplitude of z-direction in in V/m
+    frequency: float  # Frequency of the cosinusoid wave in Hz
+    phase: float  # Phase of the cosinusoid, in radians
+    duration: float  # duration of the signal, not including ramp up and ramp down in ms
+    delay: float  # start time delay in ms
+    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
+    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
+
+
 class SonataConfig:
     __slots__ = (
         "_circuit_conf",  # libsonata.CircuitConfig
@@ -343,7 +358,18 @@ class SonataConfig:
             stimulus["Name"] = name
             if stimulus["Pattern"] == "SpatiallyUniformEField":
                 fields = [
-                    self._translate_dict({}, field) for field in self._sim_conf.input(name).fields
+                    EField(
+                        duration=self._sim_conf.input(name).duration,
+                        delay=self._sim_conf.input(name).delay,
+                        ex=field.Ex,
+                        ey=field.Ey,
+                        ez=field.Ez,
+                        frequency=field.frequency,
+                        phase=field.phase,
+                        ramp_up_time=self._sim_conf.input(name).ramp_up_time,
+                        ramp_down_time=self._sim_conf.input(name).ramp_down_time,
+                    )
+                    for field in self._sim_conf.input(name).fields
                 ]
                 stimulus["Fields"] = fields
             stimuli.append(stimulus)

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -925,18 +925,9 @@ class SpatiallyUniformEField(BaseStim):
                 es.apply_segment_potentials()
 
     def parse_check_all_parameters(self, stim_info: dict):
-        self.duration = float(stim_info["Duration"])  # duration [ms]
+        self.duration = float(stim_info["Duration"])
         self.dt = float(SimConfig.run_conf.dt)
-        self.delay = float(stim_info["Delay"])  # start time [ms]
-        if not (np.isclose(self.delay % self.dt, 0) or np.isclose(self.delay % self.dt, self.dt)):
-            self.delay = np.ceil(self.delay / self.dt) * self.dt
-            logging.warning(
-                "%s delay %s is not divisible by dt %s, rounded up to the next time point %s",
-                self.__class__.__name__,
-                stim_info["Delay"],
-                self.dt,
-                self.delay,
-            )
+        self.delay = float(stim_info["Delay"])
         self.fields = stim_info["Fields"]
         self.ramp_up_time = stim_info.get("RampUpTime", 0.0)
         self.ramp_down_time = stim_info.get("RampDownTime", 0.0)

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -866,10 +866,8 @@ class SpatiallyUniformEField:
             es = ElectrodeSource(stim_info["Fields"])
             gid = target_point_list.gid
             if gid in self.stimList:
-                # Consolidate with existing stimulus
                 self.stimList[gid] += es
             else:
-                # Add new stimulus
                 self.stimList[gid] = es
 
                 # Compute segment displacement from the ground point where potential is 0,

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import libsonata
@@ -831,6 +832,21 @@ class SEClamp(BaseStim):
             logging.warning("%s ignores delay", self.__class__.__name__)
 
 
+@dataclass
+class EField:
+    """Dataclass for electric field definition, currently cosinusoid"""
+
+    ex: float  # Peak amplitude of x-direction in in V/m
+    ey: float  # Peak amplitude of y-direction in in V/m
+    ez: float  # Peak amplitude of z-direction in in V/m
+    frequency: float  # Frequency of the cosinusoid wave in Hz
+    phase: float  # Phase of the cosinusoid, in radians
+    duration: float  # duration of the signal, not including ramp up and ramp down in ms
+    delay: float  # start time delay in ms
+    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
+    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
+
+
 @StimulusManager.register_type
 class SpatiallyUniformEField(BaseStim):
     """Inject a spatially-uniform, temporally-oscillating extracellular potential field.
@@ -866,17 +882,10 @@ class SpatiallyUniformEField(BaseStim):
 
         # apply stim to each point in target_points
         for target_point_list in target_points:
-            es = ElectrodeSource(
-                delay=self.delay,
-                duration=self.duration,
-                fields=self.fields,
-                ramp_up_time=self.ramp_up_time,
-                ramp_down_time=self.ramp_down_time,
-            )
+            es = ElectrodeSource(self.efields)
             gid = target_point_list.gid
             if gid in self.stimList:
-                # Consolidate with existing stimulus - not yet supported in mod impl
-                # TODO: update iadd method to allow: self.stimList[gid] += es; raise error for now
+                # Consolidate with existing stimulus
                 self.stimList[gid] += es
             else:
                 # Add new stimulus
@@ -925,12 +934,20 @@ class SpatiallyUniformEField(BaseStim):
                 es.apply_segment_potentials()
 
     def parse_check_all_parameters(self, stim_info: dict):
-        self.duration = float(stim_info["Duration"])
-        self.dt = float(SimConfig.run_conf.dt)
-        self.delay = float(stim_info["Delay"])
-        self.fields = stim_info["Fields"]
-        self.ramp_up_time = stim_info.get("RampUpTime", 0.0)
-        self.ramp_down_time = stim_info.get("RampDownTime", 0.0)
+        self.efields = [
+            EField(
+                ex=f["Ex"],
+                ey=f["Ey"],
+                ez=f["Ez"],
+                frequency=f["Frequency"],
+                phase=f["Phase"],
+                duration=stim_info["Duration"],
+                delay=stim_info["Delay"],
+                ramp_up_time=stim_info["RampUpTime"],
+                ramp_down_time=stim_info["RampDownTime"],
+            )
+            for f in stim_info["Fields"]
+        ]
         return True
 
     @staticmethod

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -867,13 +867,11 @@ class SpatiallyUniformEField(BaseStim):
         # apply stim to each point in target_points
         for target_point_list in target_points:
             es = ElectrodeSource(
-                base_amp=0,
                 delay=self.delay,
                 duration=self.duration,
                 fields=self.fields,
                 ramp_up_time=self.ramp_up_time,
                 ramp_down_time=self.ramp_down_time,
-                dt=self.dt,
             )
             gid = target_point_list.gid
             if gid in self.stimList:

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from .core import NeuronWrapper as Nd, random
 from .core.configuration import ConfigurationError, SimConfig
-from .core.stimuli import ConductanceSource, CurrentSource, EField, ElectrodeSource
+from .core.stimuli import ConductanceSource, CurrentSource, ElectrodeSource
 from .utils.logging import log_verbose
 
 if TYPE_CHECKING:
@@ -832,7 +832,7 @@ class SEClamp(BaseStim):
 
 
 @StimulusManager.register_type
-class SpatiallyUniformEField(BaseStim):
+class SpatiallyUniformEField:
     """Inject a spatially-uniform, temporally-oscillating extracellular potential field.
     The potential field is defined as the sum of multiple potential fields which vary cosinusoidally
     in time, and whose spatial gradient (i.e., E field) is constant.
@@ -861,12 +861,9 @@ class SpatiallyUniformEField(BaseStim):
         """Process stimulus block for target cells.
         Creates ElectrodeSource for new cells or merges with existing stimuli.
         """
-        # parse parameters for the current stimus block
-        self.parse_check_all_parameters(stim_info)
-
         # apply stim to each point in target_points
         for target_point_list in target_points:
-            es = ElectrodeSource(self.efields)
+            es = ElectrodeSource(stim_info["Fields"])
             gid = target_point_list.gid
             if gid in self.stimList:
                 # Consolidate with existing stimulus
@@ -916,23 +913,6 @@ class SpatiallyUniformEField(BaseStim):
         if cls._instance:
             for es in cls._instance.stimList.values():
                 es.apply_segment_potentials()
-
-    def parse_check_all_parameters(self, stim_info: dict):
-        self.efields = [
-            EField(
-                ex=f["Ex"],
-                ey=f["Ey"],
-                ez=f["Ez"],
-                frequency=f["Frequency"],
-                phase=f["Phase"],
-                duration=stim_info["Duration"],
-                delay=stim_info["Delay"],
-                ramp_up_time=stim_info["RampUpTime"],
-                ramp_down_time=stim_info["RampDownTime"],
-            )
-            for f in stim_info["Fields"]
-        ]
-        return True
 
     @staticmethod
     def get_segment_position(sec_seg_points, soma_local_position, section, x, func_loc2glob=None):

--- a/neurodamus/stimulus_manager.py
+++ b/neurodamus/stimulus_manager.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import libsonata
@@ -28,7 +27,7 @@ import numpy as np
 
 from .core import NeuronWrapper as Nd, random
 from .core.configuration import ConfigurationError, SimConfig
-from .core.stimuli import ConductanceSource, CurrentSource, ElectrodeSource
+from .core.stimuli import ConductanceSource, CurrentSource, EField, ElectrodeSource
 from .utils.logging import log_verbose
 
 if TYPE_CHECKING:
@@ -830,21 +829,6 @@ class SEClamp(BaseStim):
         self.time_vec = Nd.h.Vector(np.cumsum(duration_levels))
         if self.delay > 0:
             logging.warning("%s ignores delay", self.__class__.__name__)
-
-
-@dataclass
-class EField:
-    """Dataclass for electric field definition, currently cosinusoid"""
-
-    ex: float  # Peak amplitude of x-direction in in V/m
-    ey: float  # Peak amplitude of y-direction in in V/m
-    ez: float  # Peak amplitude of z-direction in in V/m
-    frequency: float  # Frequency of the cosinusoid wave in Hz
-    phase: float  # Phase of the cosinusoid, in radians
-    duration: float  # duration of the signal, not including ramp up and ramp down in ms
-    delay: float  # start time delay in ms
-    ramp_up_time: float  # duration during which amplitude ramps up linearly from 0, in ms
-    ramp_down_time: float  # duration during which amplitude ramps down linearly to 0, in ms
 
 
 @StimulusManager.register_type

--- a/tests/unit-mpi/test_dry_run.py
+++ b/tests/unit-mpi/test_dry_run.py
@@ -45,7 +45,7 @@ def test_dry_run_memory_use(create_tmp_simulation_config_file, mpi_ranks):
 
     isMacOS = PLATFORM_SYSTEM == "Darwin"
     if rank == 0:
-        assert (100.0 if isMacOS else 120.0) <= nd._dry_run_stats.base_memory <= (
+        assert (100.0 if isMacOS else 110.0) <= nd._dry_run_stats.base_memory <= (
             200.0 if isMacOS else 300.0)
         assert 0.4 <= nd._dry_run_stats.cell_memory_total <= 7.0
         assert 0.0 <= nd._dry_run_stats.synapse_memory_total <= 0.02

--- a/tests/unit-mpi/test_extracellular_stimulus.py
+++ b/tests/unit-mpi/test_extracellular_stimulus.py
@@ -3,56 +3,11 @@ import numpy.testing as npt
 import pytest
 
 from tests.conftest import RINGTEST_DIR
+from tests.utils import get_expected_extracellular_potentials
 
 from neurodamus import Neurodamus
 from neurodamus.core import MPI
 from neurodamus.stimulus_manager import SpatiallyUniformEField
-
-REF_CONSTANT_BIGCELL = np.array(
-    [
-        -0.0,
-        -0.160722,
-        -0.4821677,
-        -0.8036128,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.843793,
-        -0.60271,
-        -0.361626,
-        -0.120542,
-    ]
-)
-
-REF_CONSTANT_SMALLCELL = [
-    0.0,
-    -0.184506,
-    -0.553517,
-    -0.922529,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -1.107034,
-    -0.968655,
-    -0.691896,
-    -0.415138,
-    -0.138379,
-]
-
-REF_CONSTANT = {0: REF_CONSTANT_BIGCELL, 1: REF_CONSTANT_SMALLCELL}
 
 
 @pytest.mark.parametrize(
@@ -101,8 +56,7 @@ def test_one_constant_field(create_tmp_simulation_config_file, mpi_ranks):
     stimulus = n._stim_manager._stimulus[0]
     assert isinstance(stimulus, SpatiallyUniformEField)
     gid = local_gids[0]
-    cell = n.circuits.get_node_manager("RingA").get_cell(gid)
-    cellref = cell.CellRef
+    cellref = n.circuits.get_node_manager("RingA").get_cellref(gid)
     es = stimulus.stimList[gid]
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
 
@@ -111,7 +65,13 @@ def test_one_constant_field(create_tmp_simulation_config_file, mpi_ranks):
     rec_dend.record(dend_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(rec_dend, REF_CONSTANT[gid], atol=1e-6)
+
+    assert len(es.fields) == 1
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    es = stimulus.stimList[gid]
+    efi = es.segment_efield_integrators[3] if gid == 0 else es.segment_efield_integrators[1]
+    ref = get_expected_extracellular_potentials(tot_tvec, efi, es.fields)
+    npt.assert_allclose(rec_dend, ref)
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)
 

--- a/tests/unit-mpi/test_extracellular_stimulus.py
+++ b/tests/unit-mpi/test_extracellular_stimulus.py
@@ -66,11 +66,11 @@ def test_one_constant_field(create_tmp_simulation_config_file, mpi_ranks):
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
 
-    assert len(es.fields) == 1
+    assert len(es.efields) == 1
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     es = stimulus.stimList[gid]
     efi = es.segment_efield_integrators[3] if gid == 0 else es.segment_efield_integrators[1]
-    ref = get_expected_extracellular_potentials(tot_tvec, efi, es.fields)
+    ref = get_expected_extracellular_potentials(tot_tvec, efi, es.efields)
     npt.assert_allclose(rec_dend, ref)
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -7,89 +7,15 @@ from scipy.signal import find_peaks
 
 from tests.conftest import RINGTEST_DIR
 from tests.utils import (
-    f_cos,
-    make_ramp_envelope,
+    get_expected_extracellular_potential,
     read_ascii_report,
     record_compartment_reports,
     write_ascii_reports,
 )
 
-from neurodamus import Neurodamus, Node
+from neurodamus import Neurodamus
 from neurodamus.core.stimuli import ElectrodeSource
 from neurodamus.stimulus_manager import SpatiallyUniformEField
-
-pytestmark = pytest.mark.skip(reason="not implemented yet")
-
-# Reference of various stim vectors without delay
-REF_COSINE = np.array(
-    [
-        -0.0,
-        -0.204561,
-        -0.156271,
-        0.156271,
-        0.409122,
-        0.505702,
-        0.409122,
-        0.156271,
-        -0.156271,
-        -0.409122,
-        -0.505702,
-        -0.409122,
-        -0.156271,
-        0.156271,
-        0.409122,
-        0.337135,
-        0.136374,
-        0.0,
-        0.0,
-    ]
-)
-
-REF_CONSTANT = np.array(
-    [
-        -0.0,
-        -0.482168,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.64289,
-        -0.321445,
-        -0.0,
-        0.0,
-    ]
-)
-
-REF_CONSTANT_SMALLCELL = [
-    -0.0,
-    -8.006978,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -16.013957,
-    -10.675971,
-    -5.337986,
-    -0.0,
-    0.0,
-]
 
 
 @pytest.mark.parametrize(
@@ -99,13 +25,13 @@ REF_CONSTANT_SMALLCELL = [
             "simconfig_fixture": "ringtest_baseconfig",
             "extra_config": {
                 "network": str(RINGTEST_DIR / "circuit_config_bigA.json"),
-                "run": {"dt": 1},
+                "run": {"dt": 1, "tstop": 20},
                 "inputs": {
                     "ex_efields_1": {
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
                         "delay": 0,
-                        "duration": 10,
+                        "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
                             {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
@@ -131,7 +57,7 @@ REF_CONSTANT_SMALLCELL = [
     ],
     indirect=True,
 )
-def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR0914
+def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     """
     Two stimulus blocks, one contains a cosine field and the other contains a constant field,
     they should be summed
@@ -149,8 +75,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR091
     assert len(n._stim_manager._stimulus) == 1
     stimulus = n._stim_manager._stimulus[0]
     assert stimulus == SpatiallyUniformEField._instance
-    cell_manager = n.circuits.get_node_manager("RingA")
-    cellref = cell_manager.get_cellref(0)
+    cellref = n.circuits.get_node_manager("RingA").get_cellref(0)
     rec_dend = Nd.Vector()
     rec_dend.record(cellref.dend[0](0.25).extracellular._ref_e)
     rec_soma = Nd.Vector()
@@ -163,35 +88,14 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR091
     assert isinstance(es, ElectrodeSource)
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
     assert len(es.fields) == 2
-    d1 = es.fields[0].duration + es.fields[0].ramp_up_time + es.fields[0].ramp_down_time
-    d2 = es.fields[1].duration + es.fields[1].ramp_up_time + es.fields[1].ramp_down_time
-    dt = Nd.dt
     dend_efi = es.segment_efield_integrators[3]
 
-    t1_vec = np.concatenate([[0], np.arange(dt / 2, d1, dt)])
-    ramp1_vec = make_ramp_envelope(
-        t1_vec, es.fields[0].ramp_up_time, es.fields[0].ramp_down_time, es.fields[0].duration
-    )
-    t2_vec = np.concatenate([[0], np.arange(dt / 2, d2, dt)])
-    ramp2_vec = make_ramp_envelope(
-        t2_vec, es.fields[1].ramp_up_time, es.fields[1].ramp_down_time, es.fields[1].duration
-    )
-    tot_tvec = np.concatenate([[0], np.arange(dt / 2, Nd.tstop, dt)])
-    ref_dend = (
-        f_cos(
-            t1_vec, es.fields[0].frequency, es.fields[0].phase, dend_efi.get_potential_amplitude(0)
-        )
-        * ramp1_vec
-        + f_cos(
-            t2_vec, es.fields[1].frequency, es.fields[1].phase, dend_efi.get_potential_amplitude(1)
-        )
-        * ramp2_vec
-    )
-    ref_zeros = np.zeros(len(tot_tvec))
-    ref_final = ref_zeros.copy()
-    ref_final[: len(ref_dend)] += ref_dend
-    npt.assert_allclose(rec_soma, ref_zeros)
-    npt.assert_allclose(rec_dend, ref_final)
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    ref_soma = np.zeros(len(tot_tvec))
+    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+
+    npt.assert_allclose(rec_soma, ref_soma)
+    npt.assert_allclose(rec_dend, ref_dend)
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)
     assert es.segment_displacements is None
@@ -210,7 +114,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR091
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
                         "delay": 5,
-                        "duration": 10,
+                        "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
                             {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
@@ -221,7 +125,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR091
                     "ex_efields_2": {
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
-                        "delay": 4.5,
+                        "delay": 4.4,
                         "duration": 10,
                         "node_set": "RingA_Cell0",
                         "fields": [
@@ -236,10 +140,9 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR091
     ],
     indirect=True,
 )
-def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file, capsys):
+def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file):
     """
     1. Check the combination of two stimulus blocks, one with delay.
-    2. The original delay 4.5 is not divisible by dt 1.0, rounded up to the next time point.
     3. Record one segment extracellular._ref_e and run simulation, check the values
     """
     from neurodamus.core import (
@@ -247,43 +150,24 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file, capsys):
     )  # Import at function level, otherwise will impact other tests
 
     n = Neurodamus(create_tmp_simulation_config_file)
+    cellref = n.circuits.get_node_manager("RingA").get_cellref(0)
+    assert len(n._stim_manager._stimulus) == 1
     stimulus = n._stim_manager._stimulus[0]
-    duration = stimulus.duration + stimulus.ramp_up_time + stimulus.ramp_down_time
-    dt = stimulus.dt
-    captured = capsys.readouterr()
-    warning = (
-        "[WARNING] SpatiallyUniformEField delay 4.5 is not divisible by dt 1.0, "
-        "rounded up to the next time point 5.0"
-    )
-    assert warning in captured.out
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 5)
-    ref_timevec = [0, *np.arange(delay, delay + duration + dt + 0.1, dt)]
-    ref_stimvec = np.zeros(len(ref_timevec))
-    es = stimulus.stimList[0]
-    soma_stim_vec = es.segment_potentials[0]
-    npt.assert_allclose(es.time_vec, ref_timevec)
-    npt.assert_allclose(soma_stim_vec, ref_stimvec)
-    dend_stim_vec = es.segment_potentials[3]
-    npt.assert_allclose(dend_stim_vec, np.append(0, REF_COSINE + REF_CONSTANT), rtol=1e-5)
-
-    # record segment extracellular_e, check result after simulation run
-    cell_manager = n.circuits.get_node_manager("RingA")
-    dend_seg = cell_manager.get_cellref(0).dend[0](0.25)
-    rec_seg_e = Nd.h.Vector()
-    rec_seg_e.record(dend_seg.extracellular._ref_e)
+    rec_dend = Nd.Vector()
+    rec_dend.record(cellref.dend[0](0.25).extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    assert len(rec_seg_e) == 31
-    # check extracellular_e has been assigned to the correct values
-    npt.assert_allclose(
-        rec_seg_e[6:25],
-        REF_COSINE + REF_CONSTANT,
-        rtol=1e-5,
-    )
-    # check extracellular_e is back to 0 before and after injection
-    npt.assert_allclose(rec_seg_e[0:5], 0)
-    npt.assert_allclose(rec_seg_e[26:], 0)
+
+    assert list(stimulus.stimList.keys()) == [0]
+    es = stimulus.stimList[0]
+    assert isinstance(es, ElectrodeSource)
+    assert len(es.fields) == 2
+
+    dend_efi = es.segment_efield_integrators[3]
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+
+    npt.assert_allclose(rec_dend, ref_dend)
 
 
 @pytest.mark.parametrize(
@@ -293,13 +177,13 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file, capsys):
             "simconfig_fixture": "ringtest_baseconfig",
             "extra_config": {
                 "network": str(RINGTEST_DIR / "circuit_config_bigA.json"),
-                "run": {"dt": 1},
+                "run": {"dt": 1, "tstop": 20},
                 "inputs": {
                     "ex_efields_1": {
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
                         "delay": 5,
-                        "duration": 10,
+                        "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
                             {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
@@ -310,7 +194,7 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file, capsys):
                     "ex_efields_2": {
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
-                        "delay": 5,
+                        "delay": 4.4,
                         "duration": 10,
                         "node_set": "RingA_Cell0",
                         "fields": [
@@ -322,8 +206,8 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file, capsys):
                     "ex_efields_3": {
                         "input_type": "extracellular_stimulation",
                         "module": "spatially_uniform_e_field",
-                        "delay": 5,
-                        "duration": 10,
+                        "delay": 4.5,
+                        "duration": 6,
                         "node_set": "RingA_Cell0",
                         "fields": [
                             {"Ex": 200, "Ey": -100, "Ez": 100, "frequency": 0.001},
@@ -341,29 +225,28 @@ def test_three_stimulus_blocks_delay(create_tmp_simulation_config_file):
     """
     Check three fields in the stimlus, cosine + constant + cosine with small freq(almost constant)
     """
+    from neurodamus.core import (
+        NeuronWrapper as Nd,
+    )  # Import at function level, otherwise will impact other tests
 
-    n = Node(create_tmp_simulation_config_file)
-    n.load_targets()
-    n.create_cells()
-    n.enable_stimulus()
+    n = Neurodamus(create_tmp_simulation_config_file)
     stimulus = n._stim_manager._stimulus[0]
-    duration = stimulus.duration + stimulus.ramp_up_time + stimulus.ramp_down_time
-    dt = stimulus.dt
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 5)
-    ref_timevec = [0, *np.arange(delay, delay + duration + dt + 0.1, dt)]
-    ref_stimvec = np.zeros(len(ref_timevec))
+    cellref = n.circuits.get_node_manager("RingA").get_cellref(0)
+    stimulus = n._stim_manager._stimulus[0]
+    rec_dend = Nd.Vector()
+    rec_dend.record(cellref.dend[0](0.25).extracellular._ref_e)
+    Nd.finitialize()  # reinit for the recordings to be registered
+    n.run()
+
     es = stimulus.stimList[0]
-    soma_stim_vec = es.segment_potentials[0]
-    npt.assert_allclose(es.time_vec, ref_timevec)
-    npt.assert_allclose(soma_stim_vec, ref_stimvec)
-    dend_stim_vec = es.segment_potentials[3]
-    npt.assert_allclose(
-        dend_stim_vec,
-        np.append(0, REF_COSINE + REF_CONSTANT + 2 * REF_CONSTANT),
-        rtol=1e-6,
-    )
-    n.clear_model()
+    assert len(es.fields) == 3
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    dend_efi = es.segment_efield_integrators[3]
+
+    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+
+    npt.assert_allclose(rec_dend, ref_dend)
 
 
 @pytest.mark.parametrize(
@@ -412,28 +295,38 @@ def test_two_blocks_nodeset_overlap(create_tmp_simulation_config_file):
     cell 1,2 contain the 2nd stimluli
     """
 
-    n = Node(create_tmp_simulation_config_file)
-    n.load_targets()
-    n.create_cells()
-    n.enable_stimulus()
-    stimulus = n._stim_manager._stimulus[0]
-    duration = stimulus.duration + stimulus.ramp_up_time + stimulus.ramp_down_time
-    dt = stimulus.dt
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 5)
-    ref_timevec = [0, *np.arange(delay, delay + duration + dt + 0.1, dt)]
-    # cell 0
-    es0 = stimulus.stimList[0]
-    dend_stim_vec = es0.segment_potentials[3]
-    npt.assert_allclose(es0.time_vec, ref_timevec)
-    npt.assert_allclose(dend_stim_vec, np.append(0, REF_COSINE + REF_CONSTANT), rtol=1e-5)
+    from neurodamus.core import (
+        NeuronWrapper as Nd,
+    )  # Import at function level, otherwise will impact other tests
 
-    # cell 1
+    n = Neurodamus(create_tmp_simulation_config_file)
+    cellref0 = n.circuits.get_node_manager("RingA").get_cellref(0)
+    cellref1 = n.circuits.get_node_manager("RingA").get_cellref(1)
+    stimulus = n._stim_manager._stimulus[0]
+    rec_dend0 = Nd.Vector()
+    rec_dend0.record(cellref0.dend[0](0.25).extracellular._ref_e)
+    rec_dend1 = Nd.Vector()
+    rec_dend1.record(cellref1.dend[0](0.25).extracellular._ref_e)
+    Nd.finitialize()  # reinit for the recordings to be registered
+    n.run()
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+
+    # cell 0, big cell
+    es0 = stimulus.stimList[0]
+    assert len(es0.fields) == 2
+    ref0 = get_expected_extracellular_potential(
+        tot_tvec, es0.segment_efield_integrators[3], es0.fields
+    )
+    npt.assert_allclose(rec_dend0, ref0)
+
+    # cell 1, small cell
     es1 = stimulus.stimList[1]
-    dend_stim_vec = es1.segment_potentials[3]
-    npt.assert_allclose(es1.time_vec, ref_timevec)
-    npt.assert_allclose(dend_stim_vec, np.append(0, REF_CONSTANT_SMALLCELL), rtol=1e-5)
-    n.clear_model()
+    assert len(es1.fields) == 1
+    ref1 = get_expected_extracellular_potential(
+        tot_tvec, es1.segment_efield_integrators[1], es1.fields
+    )
+    npt.assert_allclose(rec_dend1, ref1)
 
 
 @pytest.mark.parametrize(
@@ -478,61 +371,27 @@ def test_two_blocks_time_overlap(create_tmp_simulation_config_file):
     Check 2 stimulus blocks with different time window
     block 1 : [5,17], block 2: [0,7]
     """
+    from neurodamus.core import (
+        NeuronWrapper as Nd,
+    )  # Import at function level, otherwise will impact other tests
 
-    n = Node(create_tmp_simulation_config_file)
-    n.load_targets()
-    n.create_cells()
-    n.enable_stimulus()
+    n = Neurodamus(create_tmp_simulation_config_file)
     stimulus = n._stim_manager._stimulus[0]
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 0)  # delay of the last stimulus block
-    ref_timevec = [
-        0.0,
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-        17.0,
-        18.0,
-    ]
-    ref_stimvec = [
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -1.168896,
-        -1.120606,
-        0.156271,
-        0.409122,
-        0.505702,
-        0.409122,
-        0.156271,
-        -0.156271,
-        -0.409122,
-        -0.337135,
-        -0.136374,
-        -0.0,
-        0.0,
-    ]
+    cellref = n.circuits.get_node_manager("RingA").get_cellref(0)
+    stimulus = n._stim_manager._stimulus[0]
+    rec_dend = Nd.Vector()
+    rec_dend.record(cellref.dend[0](0.25).extracellular._ref_e)
+    Nd.finitialize()  # reinit for the recordings to be registered
+    n.run()
+
     es = stimulus.stimList[0]
-    dend_stim_vec = es.segment_potentials[3]
-    npt.assert_allclose(es.time_vec, ref_timevec)
-    npt.assert_allclose(dend_stim_vec, ref_stimvec, rtol=1e-5)
-    n.clear_model()
+    assert len(es.fields) == 2
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    dend_efi = es.segment_efield_integrators[3]
+
+    ref = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+    npt.assert_allclose(rec_dend, ref)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -6,7 +6,13 @@ import pytest
 from scipy.signal import find_peaks
 
 from tests.conftest import RINGTEST_DIR
-from tests.utils import read_ascii_report, record_compartment_reports, write_ascii_reports
+from tests.utils import (
+    f_cos,
+    make_ramp_envelope,
+    read_ascii_report,
+    record_compartment_reports,
+    write_ascii_reports,
+)
 
 from neurodamus import Neurodamus, Node
 from neurodamus.core.stimuli import ElectrodeSource
@@ -86,215 +92,6 @@ REF_CONSTANT_SMALLCELL = [
 ]
 
 
-def test_combine_time_stim_vectors():  # noqa: PLR0915
-    # case 1, overlap, no delay
-    t1_vec = np.array([0, 0.5, 1.0, 1.5, 2, 2.5, 3.0])
-    stim1_vec = np.array([[10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 0.0]])
-    t2_vec = np.array([0, 0.5, 1, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0])
-    stim2_vec = np.array([[100, 100, 100, 100.0, 100.0, 100.0, 100.0, 100.0, 0.0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=False, is_delay2=False, dt=0.5
-    )
-    npt.assert_allclose(
-        res_time_vec,
-        [
-            0,
-            0.5,
-            1.0,
-            1.5,
-            2.0,
-            2.5,
-            3.0,
-            3.5,
-            4.0,
-        ],
-    )
-    npt.assert_allclose(
-        res_stim_vec, [[110.0, 110.0, 110.0, 110.0, 110.0, 110.0, 100.0, 100.0, 0.0]]
-    )
-
-    # case 2, overlap, delay
-    t1_vec = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
-    stim1_vec = np.array([[0.0, 10.0, 10.0, 10.0, 10.0, 10.0, 0.0]])
-    t2_vec = np.array([0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
-    stim2_vec = np.array([[0.0, 100.0, 100.0, 100.0, 100.0, 100.0, 0.0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=1.0
-    )
-    npt.assert_allclose(
-        res_time_vec,
-        [
-            0.0,
-            1.0,
-            2.0,
-            3.0,
-            4.0,
-            5.0,
-            6.0,
-            7.0,
-            8.0,
-        ],
-    )
-    npt.assert_allclose(res_stim_vec, [[0, 10.0, 10.0, 110.0, 110.0, 110.0, 100.0, 100.0, 0.0]])
-
-    # case 3, no overlap, t1_vec before t2_vec
-    t1_vec = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4])
-    stim1_vec = np.array([[10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 0.0, 0.0]])
-    t2_vec = np.array([0.0, 30.0, 30.2, 30.4, 30.6, 30.8, 31.0, 31.2])
-    stim2_vec = np.array([[0.0, 100.0, 100.0, 100.0, 100.0, 100.0, 0.0, 0.0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=False, is_delay2=True, dt=0.2
-    )
-    npt.assert_allclose(
-        res_time_vec, [0, 0.2, 0.4, 0.6, 0.8, 1, 1.2, 1.4, 30.0, 30.2, 30.4, 30.6, 30.8, 31, 31.2]
-    )
-    npt.assert_allclose(
-        res_stim_vec,
-        [
-            [
-                10.0,
-                10.0,
-                10.0,
-                10.0,
-                10.0,
-                10.0,
-                0.0,
-                0.0,
-                100.0,
-                100.0,
-                100.0,
-                100.0,
-                100.0,
-                0.0,
-                0.0,
-            ]
-        ],
-    )
-
-    # case 4, full inclusion, t2 with delay
-    t1_vec = np.array([0.0, 1.2, 2.4, 3.6, 4.8, 6, 7.2, 8.4])
-    stim1_vec = np.array([[0.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 0.0]])
-    t2_vec = np.array([0.0, 2.4, 3.6, 4.8, 6, 7.2])
-    stim2_vec = np.array([[0.0, 100.0, 100.0, 100.0, 0.0, 0.0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=False, is_delay2=True, dt=1.2
-    )
-    npt.assert_allclose(
-        res_time_vec,
-        [
-            0,
-            1.2,
-            2.4,
-            3.6,
-            4.8,
-            6,
-            7.2,
-            8.4,
-        ],
-    )
-    npt.assert_allclose(res_stim_vec, [[0, 10, 110, 110, 110, 10, 10, 0]])
-
-    # case 5, no overlap, t2_vec before t1_vec
-    t1_vec = np.array([0.0, 30.0, 30.025, 30.05, 30.075, 31.1, 31.125])
-    stim1_vec = np.array([[0.0, 100.0, 100.0, 100.0, 100.0, 100.0, 0]])
-
-    t2_vec = np.array([0.0, 11.0, 11.025, 11.05, 11.075, 11.1, 11.125])
-    stim2_vec = np.array([[0.0, 10.0, 10.0, 10.0, 10.0, 10.0, 0]])
-
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=0.025
-    )
-    npt.assert_allclose(
-        res_time_vec,
-        [0.0, 11, 11.025, 11.05, 11.075, 11.1, 11.125, 30.0, 30.025, 30.05, 30.075, 31.1, 31.125],
-    )
-    npt.assert_allclose(res_stim_vec, [[0.0, 10, 10, 10, 10, 10, 0, 100, 100, 100, 100, 100, 0]])
-
-    # case 6, no overlap, t2_vec before t1_vec, with delay
-    t1_vec = np.array([0, 30.0, 30.2, 30.4, 30.6, 30.8, 31.0])
-    stim1_vec = np.array([[0, 100, 100, 100, 100, 100, 0]])
-
-    t2_vec = np.array([0.0, 10.0, 10.2, 10.4, 10.6])
-    stim2_vec = np.array([[0.0, 10, 10, 10, 0]])
-
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=0.2
-    )
-    npt.assert_allclose(
-        res_time_vec, [0.0, 10.0, 10.2, 10.4, 10.6, 30.0, 30.2, 30.4, 30.6, 30.8, 31.0]
-    )
-    npt.assert_allclose(res_stim_vec, [[0, 10, 10, 10, 0, 100, 100, 100, 100, 100, 0]])
-
-    # case 7 t1 and t2 is continuous
-    # t1 before t2
-    t1_vec = np.array([0, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0])
-    stim1_vec = np.array([[0, 100, 100, 100, 100, 100, 0]])
-    t2_vec = np.array([0.0, 10.0, 10.2, 10.4, 10.6])
-    stim2_vec = np.array([[0.0, 10, 10, 10, 0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=0.2
-    )
-    npt.assert_allclose(res_time_vec, [0.0, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0, 10.2, 10.4, 10.6])
-    npt.assert_allclose(res_stim_vec, [[0, 100, 100, 100, 100, 100, 10, 10, 10, 0]])
-
-    # t1 before t2
-    t1_vec = np.array([0, 9.0, 9.2, 9.4, 9.6, 9.8])
-    stim1_vec = np.array([[0, 100, 100, 100, 100, 0]])
-    t2_vec = np.array([0.0, 10.0, 10.2, 10.4, 10.6])
-    stim2_vec = np.array([[0.0, 10, 10, 10, 0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=0.2
-    )
-    npt.assert_allclose(res_time_vec, [0.0, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0, 10.2, 10.4, 10.6])
-    npt.assert_allclose(res_stim_vec, [[0, 100, 100, 100, 100, 0, 10, 10, 10, 0]])
-
-    # t2 before t1
-    t1_vec = np.array([0, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75])
-    stim1_vec = np.array([[0, 100, 100, 100, 100, 100, 0]])
-    t2_vec = np.array([0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5])
-    stim2_vec = np.array([[10, 10, 10, 10, 10, 10, 0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=False, dt=0.25
-    )
-    npt.assert_allclose(
-        res_time_vec, [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75]
-    )
-    npt.assert_allclose(
-        res_stim_vec, [[10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 100.0, 100.0, 100.0, 100.0, 100.0, 0.0]]
-    )
-
-    # case 8, t1 = t2
-    # with delay
-    t1_vec = t2_vec = np.array([0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0])
-    stim1_vec = stim2_vec = np.array([[0, 100.0, 100.0, 100, 100, 100, 100, 100, 0]])
-
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=10.0
-    )
-    npt.assert_allclose(res_time_vec, t1_vec)
-    npt.assert_allclose(res_stim_vec, np.add(stim1_vec, stim2_vec))
-
-    # without delay
-    t1_vec = t2_vec = np.array([0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0])
-    stim1_vec = stim2_vec = np.array([[0, 100.0, 100.0, 100, 100, 100, 100, 100, 0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=False, is_delay2=False, dt=10.0
-    )
-    npt.assert_allclose(res_time_vec, t1_vec)
-    npt.assert_allclose(res_stim_vec, np.add(stim1_vec, stim2_vec))
-
-    # case 9, one time point in t1 and t2, with delay
-    t1_vec = np.array([0.0, 10.025, 10.05])
-    stim1_vec = np.array([[0.0, 10.0, 0.0]])
-    t2_vec = np.array([0.0, 10.075, 10.1])
-    stim2_vec = np.array([[0.0, 100.0, 0.0]])
-    res_time_vec, res_stim_vec = ElectrodeSource._combine_time_efields(
-        t1_vec, stim1_vec, t2_vec, stim2_vec, is_delay1=True, is_delay2=True, dt=0.025
-    )
-    npt.assert_allclose(res_time_vec, [0, 10.025, 10.05, 10.075, 10.1])
-    npt.assert_allclose(res_stim_vec, [[0, 10, 0, 100, 0]])
-
-
 @pytest.mark.parametrize(
     "create_tmp_simulation_config_file",
     [
@@ -334,49 +131,70 @@ def test_combine_time_stim_vectors():  # noqa: PLR0915
     ],
     indirect=True,
 )
-def test_two_stimulus_blocks(create_tmp_simulation_config_file):
+def test_two_stimulus_blocks(create_tmp_simulation_config_file):  # noqa: PLR0914
     """
     Two stimulus blocks, one contains a cosine field and the other contains a constant field,
-    they should be summed before applying
+    they should be summed
     1. check their stimulus managers share the same SpatiallyUniformEField instance (singleton)
-    2. check the size of segment_potentials, should be applied to all the segments, n_seg
-    3. check time_vec of stimulus, should include ramp_up_time and ramp_down_time
+    2. check the size of segment_efield_integrators, should be applied to all the segments, n_seg
+    3. check ElectrodeSource.fields list contain 2 fields
     4. check potential of 1st segment should be 0 (soma),
        for 4th segment the sum of the cosine fields and constant fields
     5. check an extracellar mechanism is added to each segment
     6. check the long/unused vectors of ElectrodeSource object are cleaned at the end
     """
+    from neurodamus.core import NeuronWrapper as Nd
 
-    n = Node(create_tmp_simulation_config_file)
-    n.load_targets()
-    n.create_cells()
-    n.enable_stimulus()
+    n = Neurodamus(create_tmp_simulation_config_file)
     assert len(n._stim_manager._stimulus) == 1
     stimulus = n._stim_manager._stimulus[0]
     assert stimulus == SpatiallyUniformEField._instance
     cell_manager = n.circuits.get_node_manager("RingA")
-    cell = cell_manager.get_cellref(0)
+    cellref = cell_manager.get_cellref(0)
+    rec_dend = Nd.Vector()
+    rec_dend.record(cellref.dend[0](0.25).extracellular._ref_e)
+    rec_soma = Nd.Vector()
+    rec_soma.record(cellref.soma[0](0.5).extracellular._ref_e)
+    Nd.finitialize()  # reinit for the recordings to be registered
+    n.run()
+
     assert list(stimulus.stimList.keys()) == [0]
     es = stimulus.stimList[0]
     assert isinstance(es, ElectrodeSource)
-    total_segments = sum(sec.nseg for sec in cell.all)
-    assert len(es.segment_potentials) == total_segments
-    duration = stimulus.duration + stimulus.ramp_up_time + stimulus.ramp_down_time
-    dt = stimulus.dt
-    ref_timevec = np.arange(0, duration + dt + 0.1, dt)
-    ref_stimvec = np.zeros(len(ref_timevec))
-    soma_stim_vec = es.segment_potentials[0]
-    npt.assert_allclose(es.time_vec, ref_timevec)
-    npt.assert_allclose(soma_stim_vec, ref_stimvec)
-    seg_stim_vec = es.segment_potentials[3]
-    npt.assert_allclose(seg_stim_vec, REF_COSINE + REF_CONSTANT, rtol=1e-5)
+    assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
+    assert len(es.fields) == 2
+    d1 = es.fields[0].duration + es.fields[0].ramp_up_time + es.fields[0].ramp_down_time
+    d2 = es.fields[1].duration + es.fields[1].ramp_up_time + es.fields[1].ramp_down_time
+    dt = Nd.dt
+    dend_efi = es.segment_efield_integrators[3]
 
-    assert all(sec.has_membrane("extracellular") for sec in cell.all)
+    t1_vec = np.concatenate([[0], np.arange(dt / 2, d1, dt)])
+    ramp1_vec = make_ramp_envelope(
+        t1_vec, es.fields[0].ramp_up_time, es.fields[0].ramp_down_time, es.fields[0].duration
+    )
+    t2_vec = np.concatenate([[0], np.arange(dt / 2, d2, dt)])
+    ramp2_vec = make_ramp_envelope(
+        t2_vec, es.fields[1].ramp_up_time, es.fields[1].ramp_down_time, es.fields[1].duration
+    )
+    tot_tvec = np.concatenate([[0], np.arange(dt / 2, Nd.tstop, dt)])
+    ref_dend = (
+        f_cos(
+            t1_vec, es.fields[0].frequency, es.fields[0].phase, dend_efi.get_potential_amplitude(0)
+        )
+        * ramp1_vec
+        + f_cos(
+            t2_vec, es.fields[1].frequency, es.fields[1].phase, dend_efi.get_potential_amplitude(1)
+        )
+        * ramp2_vec
+    )
+    ref_zeros = np.zeros(len(tot_tvec))
+    ref_final = ref_zeros.copy()
+    ref_final[: len(ref_dend)] += ref_dend
+    npt.assert_allclose(rec_soma, ref_zeros)
+    npt.assert_allclose(rec_dend, ref_final)
 
-    assert es.efields is None
+    assert all(sec.has_membrane("extracellular") for sec in cellref.all)
     assert es.segment_displacements is None
-
-    n.clear_model()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -7,7 +7,7 @@ from scipy.signal import find_peaks
 
 from tests.conftest import RINGTEST_DIR
 from tests.utils import (
-    get_expected_extracellular_potential,
+    get_expected_extracellular_potentials,
     read_ascii_report,
     record_compartment_reports,
     write_ascii_reports,
@@ -92,7 +92,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     ref_soma = np.zeros(len(tot_tvec))
-    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
 
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -165,7 +165,7 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file):
 
     dend_efi = es.segment_efield_integrators[3]
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
 
     npt.assert_allclose(rec_dend, ref_dend)
 
@@ -244,7 +244,7 @@ def test_three_stimulus_blocks_delay(create_tmp_simulation_config_file):
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     dend_efi = es.segment_efield_integrators[3]
 
-    ref_dend = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
 
     npt.assert_allclose(rec_dend, ref_dend)
 
@@ -315,7 +315,7 @@ def test_two_blocks_nodeset_overlap(create_tmp_simulation_config_file):
     # cell 0, big cell
     es0 = stimulus.stimList[0]
     assert len(es0.fields) == 2
-    ref0 = get_expected_extracellular_potential(
+    ref0 = get_expected_extracellular_potentials(
         tot_tvec, es0.segment_efield_integrators[3], es0.fields
     )
     npt.assert_allclose(rec_dend0, ref0)
@@ -323,7 +323,7 @@ def test_two_blocks_nodeset_overlap(create_tmp_simulation_config_file):
     # cell 1, small cell
     es1 = stimulus.stimList[1]
     assert len(es1.fields) == 1
-    ref1 = get_expected_extracellular_potential(
+    ref1 = get_expected_extracellular_potentials(
         tot_tvec, es1.segment_efield_integrators[1], es1.fields
     )
     npt.assert_allclose(rec_dend1, ref1)
@@ -390,7 +390,7 @@ def test_two_blocks_time_overlap(create_tmp_simulation_config_file):
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     dend_efi = es.segment_efield_integrators[3]
 
-    ref = get_expected_extracellular_potential(tot_tvec, dend_efi, es.fields)
+    ref = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
     npt.assert_allclose(rec_dend, ref)
 
 

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -89,8 +89,8 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
     assert len(es.efields) == 2
     dend_efi = es.segment_efield_integrators[3]
-    assert np.isclose(dend_efi.get_potential_amplitude(0), -0.505702)
-    assert np.isclose(dend_efi.get_potential_amplitude(1), -0.964335)
+    assert np.isclose(dend_efi.get_peak_potential(0), -0.505702)
+    assert np.isclose(dend_efi.get_peak_potential(1), -0.964335)
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     ref_soma = np.zeros(len(tot_tvec))

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -63,7 +63,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     they should be summed
     1. check their stimulus managers share the same SpatiallyUniformEField instance (singleton)
     2. check the size of segment_efield_integrators, should be applied to all the segments, n_seg
-    3. check ElectrodeSource.fields list contain 2 fields
+    3. check ElectrodeSource.efields list contain 2 fields
     4. check potential of 1st segment should be 0 (soma),
        for 4th segment the sum of the cosine fields and constant fields
     5. check an extracellar mechanism is added to each segment
@@ -87,12 +87,12 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     es = stimulus.stimList[0]
     assert isinstance(es, ElectrodeSource)
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
-    assert len(es.fields) == 2
+    assert len(es.efields) == 2
     dend_efi = es.segment_efield_integrators[3]
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     ref_soma = np.zeros(len(tot_tvec))
-    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.efields)
 
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -161,11 +161,11 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file):
     assert list(stimulus.stimList.keys()) == [0]
     es = stimulus.stimList[0]
     assert isinstance(es, ElectrodeSource)
-    assert len(es.fields) == 2
+    assert len(es.efields) == 2
 
     dend_efi = es.segment_efield_integrators[3]
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.efields)
 
     npt.assert_allclose(rec_dend, ref_dend)
 
@@ -239,12 +239,12 @@ def test_three_stimulus_blocks_delay(create_tmp_simulation_config_file):
     n.run()
 
     es = stimulus.stimList[0]
-    assert len(es.fields) == 3
+    assert len(es.efields) == 3
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     dend_efi = es.segment_efield_integrators[3]
 
-    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.efields)
 
     npt.assert_allclose(rec_dend, ref_dend)
 
@@ -314,17 +314,17 @@ def test_two_blocks_nodeset_overlap(create_tmp_simulation_config_file):
 
     # cell 0, big cell
     es0 = stimulus.stimList[0]
-    assert len(es0.fields) == 2
+    assert len(es0.efields) == 2
     ref0 = get_expected_extracellular_potentials(
-        tot_tvec, es0.segment_efield_integrators[3], es0.fields
+        tot_tvec, es0.segment_efield_integrators[3], es0.efields
     )
     npt.assert_allclose(rec_dend0, ref0)
 
     # cell 1, small cell
     es1 = stimulus.stimList[1]
-    assert len(es1.fields) == 1
+    assert len(es1.efields) == 1
     ref1 = get_expected_extracellular_potentials(
-        tot_tvec, es1.segment_efield_integrators[1], es1.fields
+        tot_tvec, es1.segment_efield_integrators[1], es1.efields
     )
     npt.assert_allclose(rec_dend1, ref1)
 
@@ -385,12 +385,12 @@ def test_two_blocks_time_overlap(create_tmp_simulation_config_file):
     n.run()
 
     es = stimulus.stimList[0]
-    assert len(es.fields) == 2
+    assert len(es.efields) == 2
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     dend_efi = es.segment_efield_integrators[3]
 
-    ref = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.fields)
+    ref = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.efields)
     npt.assert_allclose(rec_dend, ref)
 
 

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -93,10 +93,9 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     assert np.isclose(dend_efi.get_peak_potential(1), -0.964335)
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(tot_tvec, dend_efi, es.efields)
 
-    npt.assert_allclose(rec_soma, ref_soma)
+    assert all(rec_soma.as_numpy() == 0)
     npt.assert_allclose(rec_dend, ref_dend)
 
     assert all(sec.has_membrane("extracellular") for sec in cellref.all)

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -34,7 +34,7 @@ from neurodamus.stimulus_manager import SpatiallyUniformEField
                         "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
-                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
+                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100, "phase": 1.570796},
                         ],
                         "ramp_up_time": 3.0,
                         "ramp_down_time": 4.0,
@@ -117,7 +117,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
                         "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
-                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
+                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100, "phase": 1.570796},
                         ],
                         "ramp_up_time": 3.0,
                         "ramp_down_time": 4.0,
@@ -186,7 +186,7 @@ def test_two_stimulus_blocks_delay(create_tmp_simulation_config_file):
                         "duration": 5,
                         "node_set": "RingA_Cell0",
                         "fields": [
-                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100},
+                            {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100, "phase": 1.570796},
                         ],
                         "ramp_up_time": 3.0,
                         "ramp_down_time": 4.0,

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -63,7 +63,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     they should be summed
     1. check their stimulus managers share the same SpatiallyUniformEField instance (singleton)
     2. check the size of segment_efield_integrators, should be applied to all the segments, n_seg
-    3. check ElectrodeSource.efields list contain 2 fields
+    3. check ElectrodeSource.efields list contains 2 fields
     4. check potential of 1st segment should be 0 (soma),
        for 4th segment the sum of the cosine fields and constant fields
     5. check an extracellar mechanism is added to each segment
@@ -89,6 +89,8 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
     assert len(es.efields) == 2
     dend_efi = es.segment_efield_integrators[3]
+    assert np.isclose(dend_efi.get_potential_amplitude(0), -0.505702)
+    assert np.isclose(dend_efi.get_potential_amplitude(1), -0.964335)
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     ref_soma = np.zeros(len(tot_tvec))

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -110,10 +110,10 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
-    assert np.isclose(es.segment_efield_integrators[0].get_potential_amplitude(0), 0)
+    assert np.isclose(es.segment_efield_integrators[0].get_peak_potential(0), 0)
     ref_soma = np.zeros(len(tot_tvec))
     efi_dend = es.segment_efield_integrators[3]
-    assert np.isclose(efi_dend.get_potential_amplitude(0), -0.505702)
+    assert np.isclose(efi_dend.get_peak_potential(0), -0.505702)
     ref_dend = get_expected_extracellular_potentials(tot_tvec, efi_dend, es.efields)
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -103,18 +103,19 @@ def test_one_field_noramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
 
-    dt = es.dt
-    duration = es.duration
+    dt = Nd.dt
+    assert len(es.fields) == 1
+    duration = es.fields[0].duration
     efi = es.segment_efield_integrators[3]
     max_potential = 1e3 * (
-        efi.displacementX * es.fields[0]["Ex"]
-        + efi.displacementY * es.fields[0]["Ey"]
-        + efi.displacementZ * es.fields[0]["Ez"]
+        efi.displacementX * es.fields[0].ex
+        + efi.displacementY * es.fields[0].ey
+        + efi.displacementZ * es.fields[0].ez
     )  # from mV to V
 
     def f_cos(t):
         return max_potential * np.cos(
-            2 * np.pi * es.fields[0]["Frequency"] / 1000 * t + es.fields[0]["Phase"]
+            2 * np.pi * es.fields[0].frequency / 1000 * t + es.fields[0].phase
         )
 
     # original reference with vec.play with time points at every dt
@@ -238,20 +239,20 @@ def test_one_field_withramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     npt.assert_allclose(rec_dend, REF_COSINE, atol=1e-9)
     npt.assert_allclose(rec_soma, np.zeros(len(rec_dend)))
 
-    dt = es.dt
-    duration = es.duration
-    ramp_up_time = es.ramp_up_time
-    ramp_down_time = es.ramp_down_time
+    dt = Nd.dt
+    duration = es.fields[0].duration
+    ramp_up_time = es.fields[0].ramp_up_time
+    ramp_down_time = es.fields[0].ramp_down_time
     efi = es.segment_efield_integrators[3]
     max_potential = 1e3 * (
-        efi.displacementX * es.fields[0]["Ex"]
-        + efi.displacementY * es.fields[0]["Ey"]
-        + efi.displacementZ * es.fields[0]["Ez"]
+        efi.displacementX * es.fields[0].ex
+        + efi.displacementY * es.fields[0].ey
+        + efi.displacementZ * es.fields[0].ez
     )  # from mV to V
 
     def f_cos(t):
         return max_potential * np.cos(
-            2 * np.pi * es.fields[0]["Frequency"] / 1000 * t + es.fields[0]["Phase"]
+            2 * np.pi * es.fields[0].frequency / 1000 * t + es.fields[0].phase
         )
 
     t_beforebreakpoint = np.arange(dt / 2, duration + ramp_up_time + ramp_down_time, dt)

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -6,7 +6,12 @@ import pytest
 from scipy.signal import find_peaks
 
 from tests.conftest import RINGTEST_DIR
-from tests.utils import read_ascii_report, record_compartment_reports, write_ascii_reports
+from tests.utils import (
+    get_expected_extracellular_potentials,
+    read_ascii_report,
+    record_compartment_reports,
+    write_ascii_reports,
+)
 
 from neurodamus import Neurodamus
 from neurodamus.core.configuration import ConfigurationError
@@ -74,7 +79,7 @@ def test_interpolate_myelin_coordinates():
     ],
     indirect=True,
 )
-def test_one_field_noramp(create_tmp_simulation_config_file):  # noqa: PLR0914
+def test_one_field_noramp(create_tmp_simulation_config_file):
     """
     One cosinusoid field without ramp
     1. check the size of segment_potentials, should be applied to all the segments, n_seg
@@ -103,80 +108,14 @@ def test_one_field_noramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
 
-    dt = Nd.dt
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.fields) == 1
-    duration = es.fields[0].duration
-    efi = es.segment_efield_integrators[3]
-    max_potential = efi.get_potential_amplitude(0)
-
-    def f_cos(t):
-        return max_potential * np.cos(
-            2 * np.pi * es.fields[0].frequency / 1000 * t + es.fields[0].phase
-        )
-
-    # original reference with vec.play with time points at every dt
-    ref_stimvec_vecplay = [
-        -0.505702,
-        -0.409122,
-        -0.156271,
-        0.156271,
-        0.409122,
-        0.505702,
-        0.409122,
-        0.156271,
-        -0.156271,
-        -0.409122,
-        -0.505702,
-        0.0,
-    ]
-    t_vecplay = np.arange(0, duration + 1, dt)
-    # current reference with efield_integrator.mod at very t+dt/2 w.r.t BEFORE_BREAKPOINT
-    ref_stimvec_mod = [
-        0,
-        -0.4809515,
-        -0.2972444,
-        0,
-        0.2972444,
-        0.4809515,
-        0.4809515,
-        0.2972444,
-        0,
-        -0.2972444,
-        -0.4809515,
-    ]
-    t_beforebreakpoint = np.arange(dt / 2, duration, dt)
-
-    # check the references against the cosine function
-    npt.assert_allclose(f_cos(t_beforebreakpoint), ref_stimvec_mod[1:], atol=1e-9)
-    npt.assert_allclose(f_cos(t_vecplay), ref_stimvec_vecplay[:-1], atol=1e-6)
-
-    # check the actually segment.extracellular._ref_e against the current reference
-    npt.assert_allclose(rec_dend, ref_stimvec_mod, atol=1e-9)
-    npt.assert_allclose(rec_soma, np.zeros(len(rec_dend)))
-
-
-REF_COSINE = np.array(
-    [
-        0,
-        -0.08015859,
-        -0.1486222,
-        0,
-        0.2972444,
-        0.4809515,
-        0.4809515,
-        0.2972444,
-        0,
-        -0.2972444,
-        -0.4809515,
-        -0.4809515,
-        -0.2972444,
-        0,
-        0.26008885,
-        0.3005947,
-        0.18035683,
-        0.03715555,
-    ]
-)
+    ref_soma = np.zeros(len(tot_tvec))
+    ref_dend = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
+    )
+    npt.assert_allclose(rec_soma, ref_soma)
+    npt.assert_allclose(rec_dend, ref_dend)
 
 
 @pytest.mark.parametrize(
@@ -204,7 +143,7 @@ REF_COSINE = np.array(
     ],
     indirect=True,
 )
-def test_one_field_withramp(create_tmp_simulation_config_file):  # noqa: PLR0914
+def test_one_field_withramp(create_tmp_simulation_config_file):
     """
     A cosinusoid field with ramp up and down
     1. check the size of segment_potentials, should be applied to all the segments, n_seg
@@ -232,60 +171,15 @@ def test_one_field_withramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     rec_soma.record(soma_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(rec_dend, REF_COSINE, atol=1e-9)
-    npt.assert_allclose(rec_soma, np.zeros(len(rec_dend)))
 
-    dt = Nd.dt
-    duration = es.fields[0].duration
-    ramp_up_time = es.fields[0].ramp_up_time
-    ramp_down_time = es.fields[0].ramp_down_time
-    efi = es.segment_efield_integrators[3]
-    max_potential = efi.get_potential_amplitude(0)
-
-    def f_cos(t):
-        return max_potential * np.cos(
-            2 * np.pi * es.fields[0].frequency / 1000 * t + es.fields[0].phase
-        )
-
-    t_beforebreakpoint = np.arange(dt / 2, duration + ramp_up_time + ramp_down_time, dt)
-
-    # check the references against the cosine function
-    def make_ramp_envelope(t_vec):
-        envelope = np.ones(len(t_vec))
-        envelope = np.where(t_vec < ramp_up_time, t_vec / ramp_up_time, envelope)
-        envelope = np.where(
-            t_vec > ramp_up_time + duration,
-            1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time,
-            envelope,
-        )
-        return envelope
-
-    ramping_mod = make_ramp_envelope(t_beforebreakpoint)
-    npt.assert_allclose(f_cos(t_beforebreakpoint) * ramping_mod, REF_COSINE[1:], atol=1e-6)
-
-
-REF_CONSTANT = np.array(
-    [
-        -0.0,
-        -0.160722,
-        -0.4821677,
-        -0.8036128,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.964335,
-        -0.843793,
-        -0.60271,
-        -0.361626,
-        -0.120542,
-    ]
-)
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    assert len(es.fields) == 1
+    ref_soma = np.zeros(len(tot_tvec))
+    ref_dend = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
+    )
+    npt.assert_allclose(rec_soma, ref_soma)
+    npt.assert_allclose(rec_dend, ref_dend)
 
 
 @pytest.mark.parametrize(
@@ -339,8 +233,15 @@ def test_one_constant_field(create_tmp_simulation_config_file):
     rec_soma.record(soma_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(rec_dend, REF_CONSTANT, atol=1e-6)
-    npt.assert_allclose(rec_soma, np.zeros(len(rec_dend)))
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    assert len(es.fields) == 1
+    ref_soma = np.zeros(len(tot_tvec))
+    ref_dend = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
+    )
+    npt.assert_allclose(rec_soma, ref_soma)
+    npt.assert_allclose(rec_dend, ref_dend)
 
 
 @pytest.mark.parametrize(
@@ -399,8 +300,15 @@ def test_two_fields(create_tmp_simulation_config_file):
     rec_soma.record(soma_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(rec_dend, REF_COSINE + REF_CONSTANT, atol=1e-6)
-    npt.assert_allclose(rec_soma, np.zeros(len(rec_dend)))
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    assert len(es.fields) == 2
+    ref_soma = np.zeros(len(tot_tvec))
+    ref_dend = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
+    )
+    npt.assert_allclose(rec_soma, ref_soma)
+    npt.assert_allclose(rec_dend, ref_dend)
 
     assert all(sec.has_membrane("extracellular") for sec in cell.all)
 
@@ -443,10 +351,6 @@ def test_two_fields_delay(create_tmp_simulation_config_file):
 
     n = Neurodamus(create_tmp_simulation_config_file)
     stimulus = n._stim_manager._stimulus[0]
-    dt = stimulus.dt
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 5)
-
     cell_manager = n.circuits.get_node_manager("RingA")
     cell = cell_manager.get_cellref(0)
     dend_seg = cell.dend[0](0.25)
@@ -454,9 +358,14 @@ def test_two_fields_delay(create_tmp_simulation_config_file):
     rec_dend.record(dend_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(
-        rec_dend, np.concatenate([np.zeros(int(delay / dt)), REF_COSINE + REF_CONSTANT]), atol=1e-6
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    es = stimulus.stimList[0]
+    assert len(es.fields) == 2
+    ref = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
     )
+    npt.assert_allclose(rec_dend, ref)
 
 
 @pytest.mark.parametrize(
@@ -496,10 +405,6 @@ def test_three_fields_delay(create_tmp_simulation_config_file):
 
     n = Neurodamus(create_tmp_simulation_config_file)
     stimulus = n._stim_manager._stimulus[0]
-    dt = stimulus.dt
-    delay = stimulus.delay
-    npt.assert_approx_equal(delay, 5)
-
     cell_manager = n.circuits.get_node_manager("RingA")
     cell = cell_manager.get_cellref(0)
     dend_seg = cell.dend[0](0.25)
@@ -507,11 +412,14 @@ def test_three_fields_delay(create_tmp_simulation_config_file):
     rec_dend.record(dend_seg.extracellular._ref_e)
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
-    npt.assert_allclose(
-        rec_dend,
-        np.concatenate([np.zeros(int(delay / dt)), REF_COSINE + REF_CONSTANT + 2 * REF_CONSTANT]),
-        atol=1e-5,
+
+    tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
+    es = stimulus.stimList[0]
+    assert len(es.fields) == 3
+    ref = get_expected_extracellular_potentials(
+        tot_tvec, es.segment_efield_integrators[3], es.fields
     )
+    npt.assert_allclose(rec_dend, ref)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -111,11 +111,10 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
     assert np.isclose(es.segment_efield_integrators[0].get_peak_potential(0), 0)
-    ref_soma = np.zeros(len(tot_tvec))
     efi_dend = es.segment_efield_integrators[3]
     assert np.isclose(efi_dend.get_peak_potential(0), -0.505702)
     ref_dend = get_expected_extracellular_potentials(tot_tvec, efi_dend, es.efields)
-    npt.assert_allclose(rec_soma, ref_soma)
+    assert all(rec_soma.as_numpy() == 0)
     npt.assert_allclose(rec_dend, ref_dend)
 
 
@@ -175,11 +174,10 @@ def test_one_field_withramp(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
-    ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
         tot_tvec, es.segment_efield_integrators[3], es.efields
     )
-    npt.assert_allclose(rec_soma, ref_soma)
+    assert all(rec_soma.as_numpy() == 0)
     npt.assert_allclose(rec_dend, ref_dend)
 
 
@@ -237,11 +235,10 @@ def test_one_constant_field(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
-    ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
         tot_tvec, es.segment_efield_integrators[3], es.efields
     )
-    npt.assert_allclose(rec_soma, ref_soma)
+    assert all(rec_soma.as_numpy() == 0)
     npt.assert_allclose(rec_dend, ref_dend)
 
 
@@ -304,11 +301,10 @@ def test_two_fields(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 2
-    ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
         tot_tvec, es.segment_efield_integrators[3], es.efields
     )
-    npt.assert_allclose(rec_soma, ref_soma)
+    assert all(rec_soma.as_numpy() == 0)
     npt.assert_allclose(rec_dend, ref_dend)
 
     assert all(sec.has_membrane("extracellular") for sec in cell.all)

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -83,8 +83,8 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
     """
     One cosinusoid field without ramp
     1. check the size of segment_potentials, should be applied to all the segments, n_seg
-    2. check the reference potentials against the cosine function
-    3. check potentials of 1st segment should be 0 (soma), and a cosine wave for 4th segment
+    2. check potentials of 1st segment should be 0 (soma), and a cosine wave for 4th segment
+    3. check the potential amplitude of soma and 4th segment
     """
     from neurodamus.core import NeuronWrapper as Nd
 
@@ -110,10 +110,11 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
+    assert np.isclose(es.segment_efield_integrators[0].get_potential_amplitude(0), 0)
     ref_soma = np.zeros(len(tot_tvec))
-    ref_dend = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.efields
-    )
+    efi_dend = es.segment_efield_integrators[3]
+    assert np.isclose(efi_dend.get_potential_amplitude(0), -0.505702)
+    ref_dend = get_expected_extracellular_potentials(tot_tvec, efi_dend, es.efields)
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
 

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -107,11 +107,7 @@ def test_one_field_noramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     assert len(es.fields) == 1
     duration = es.fields[0].duration
     efi = es.segment_efield_integrators[3]
-    max_potential = 1e3 * (
-        efi.displacementX * es.fields[0].ex
-        + efi.displacementY * es.fields[0].ey
-        + efi.displacementZ * es.fields[0].ez
-    )  # from mV to V
+    max_potential = 1e3 * efi.get_potential_amplitude(0)  # from mV to V
 
     def f_cos(t):
         return max_potential * np.cos(
@@ -244,11 +240,7 @@ def test_one_field_withramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     ramp_up_time = es.fields[0].ramp_up_time
     ramp_down_time = es.fields[0].ramp_down_time
     efi = es.segment_efield_integrators[3]
-    max_potential = 1e3 * (
-        efi.displacementX * es.fields[0].ex
-        + efi.displacementY * es.fields[0].ey
-        + efi.displacementZ * es.fields[0].ez
-    )  # from mV to V
+    max_potential = 1e3 * efi.get_potential_amplitude(0)  # from mV to V
 
     def f_cos(t):
         return max_potential * np.cos(

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -109,10 +109,10 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
     n.run()
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    assert len(es.fields) == 1
+    assert len(es.efields) == 1
     ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -173,10 +173,10 @@ def test_one_field_withramp(create_tmp_simulation_config_file):
     n.run()
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    assert len(es.fields) == 1
+    assert len(es.efields) == 1
     ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -235,10 +235,10 @@ def test_one_constant_field(create_tmp_simulation_config_file):
     n.run()
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    assert len(es.fields) == 1
+    assert len(es.efields) == 1
     ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -302,10 +302,10 @@ def test_two_fields(create_tmp_simulation_config_file):
     n.run()
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
-    assert len(es.fields) == 2
+    assert len(es.efields) == 2
     ref_soma = np.zeros(len(tot_tvec))
     ref_dend = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)
@@ -361,9 +361,9 @@ def test_two_fields_delay(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     es = stimulus.stimList[0]
-    assert len(es.fields) == 2
+    assert len(es.efields) == 2
     ref = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_dend, ref)
 
@@ -415,9 +415,9 @@ def test_three_fields_delay(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     es = stimulus.stimList[0]
-    assert len(es.fields) == 3
+    assert len(es.efields) == 3
     ref = get_expected_extracellular_potentials(
-        tot_tvec, es.segment_efield_integrators[3], es.fields
+        tot_tvec, es.segment_efield_integrators[3], es.efields
     )
     npt.assert_allclose(rec_dend, ref)
 

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -107,7 +107,7 @@ def test_one_field_noramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     assert len(es.fields) == 1
     duration = es.fields[0].duration
     efi = es.segment_efield_integrators[3]
-    max_potential = 1e3 * efi.get_potential_amplitude(0)  # from mV to V
+    max_potential = efi.get_potential_amplitude(0)
 
     def f_cos(t):
         return max_potential * np.cos(
@@ -240,7 +240,7 @@ def test_one_field_withramp(create_tmp_simulation_config_file):  # noqa: PLR0914
     ramp_up_time = es.fields[0].ramp_up_time
     ramp_down_time = es.fields[0].ramp_down_time
     efi = es.segment_efield_integrators[3]
-    max_potential = 1e3 * efi.get_potential_amplitude(0)  # from mV to V
+    max_potential = efi.get_potential_amplitude(0)
 
     def f_cos(t):
         return max_potential * np.cos(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,9 +10,9 @@ from libsonata import EdgeStorage, ElementReportReader, SimulationConfig, SpikeR
 
 from neurodamus.core import NeuronWrapper as Nd
 from neurodamus.core.configuration import SimConfig
+from neurodamus.core.stimuli import EField
 from neurodamus.report import Report
 from neurodamus.report_parameters import create_report_parameters
-from neurodamus.stimulus_manager import EField
 from neurodamus.target_manager import TargetManager, TargetSpec
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,9 +10,9 @@ from libsonata import EdgeStorage, ElementReportReader, SimulationConfig, SpikeR
 
 from neurodamus.core import NeuronWrapper as Nd
 from neurodamus.core.configuration import SimConfig
-from neurodamus.core.stimuli import EField
 from neurodamus.report import Report
 from neurodamus.report_parameters import create_report_parameters
+from neurodamus.stimulus_manager import EField
 from neurodamus.target_manager import TargetManager, TargetSpec
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -408,8 +408,8 @@ def compare_outdat_files(file1, file2, start_time=None, end_time=None):
     return np.array_equal(np.sort(events1, axis=0), np.sort(events2, axis=0))
 
 
-def get_expected_extracellular_potential(tot_tvec, efi, fields: list[EField]):
-    """For tests regarding the extracellular stimulus, compute the expected extracellular potential
+def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
+    """For tests regarding the extracellular stimulus, compute the expected extracellular potentials
     Args:
      tot_tvec: total time vector
     efi: the Neuron EFieldIntegrator mechanism in order to get the amplitude

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,7 @@ from libsonata import EdgeStorage, ElementReportReader, SimulationConfig, SpikeR
 
 from neurodamus.core import NeuronWrapper as Nd
 from neurodamus.core.configuration import SimConfig
+from neurodamus.core.stimuli import EField
 from neurodamus.report import Report
 from neurodamus.report_parameters import create_report_parameters
 from neurodamus.target_manager import TargetManager, TargetSpec
@@ -407,21 +408,45 @@ def compare_outdat_files(file1, file2, start_time=None, end_time=None):
     return np.array_equal(np.sort(events1, axis=0), np.sort(events2, axis=0))
 
 
-def f_cos(t, freq, phase, amp):
-    """compute the cosine value"""
-    return amp * np.cos(2 * np.pi * freq / 1000 * t + phase)
+def get_expected_extracellular_potential(tot_tvec, efi, fields: list[EField]):
+    """For tests regarding the extracellular stimulus, compute the expected extracellular potential
+    Args:
+     tot_tvec: total time vector
+    efi: the Neuron EFieldIntegrator mechanism in order to get the amplitude
+    fields: list of Efields"""
 
+    def _f_cos(t, freq, phase, amp):
+        """compute the cosine value"""
+        return amp * np.cos(2 * np.pi * freq / 1000 * t + phase)
 
-def make_ramp_envelope(t_vec, ramp_up_time, ramp_down_time, duration):
-    """With a given time vector, return a vector taking into account ramp up and down time"""
-    envelope = np.ones(len(t_vec))
-    envelope = np.where(t_vec < ramp_up_time, t_vec / ramp_up_time, envelope)
-    envelope = np.where(
-        t_vec > ramp_up_time + duration,
-        1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time,
-        envelope,
-    )
-    return envelope
+    def _make_ramp_envelope(t_vec, ramp_up_time, ramp_down_time, duration):
+        """With a given time vector, return a vector taking into account ramp up and down time"""
+        envelope = np.ones(len(t_vec))
+        envelope = np.where(t_vec < ramp_up_time, t_vec / ramp_up_time, envelope)
+        envelope = np.where(
+            t_vec > ramp_up_time + duration,
+            1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time,
+            envelope,
+        )
+        return envelope
+
+    ref_dend = np.zeros(len(tot_tvec))
+    for idx, field in enumerate(fields):
+        dur = field.duration
+        delay = field.delay
+        ramp_up = field.ramp_up_time
+        ramp_down = field.ramp_down_time
+        start_idx = np.searchsorted(tot_tvec, delay)
+        stop_idx = np.searchsorted(tot_tvec, dur + ramp_up + ramp_down + delay)
+        t_vec = tot_tvec[start_idx:stop_idx] - delay
+        ramp_vec = _make_ramp_envelope(t_vec, ramp_up, ramp_down, dur)
+        ref_dend[start_idx:stop_idx] += (
+            _f_cos(t_vec, field.frequency, field.phase, efi.get_potential_amplitude(idx)) * ramp_vec
+        )
+
+        # potential is always 0 at t=0
+        ref_dend[0] = 0
+    return ref_dend
 
 
 class ReportReader:  # noqa: PLW1641

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,31 +1,28 @@
+import copy
 import json
+from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 
 import numpy as np
-from libsonata import EdgeStorage, SpikeReader, ElementReportReader, SimulationConfig
-from scipy.signal import find_peaks
-from collections import defaultdict
-from collections.abc import Iterable
+import pandas as pd
+from libsonata import EdgeStorage, ElementReportReader, SimulationConfig, SpikeReader
 
 from neurodamus.core import NeuronWrapper as Nd
 from neurodamus.core.configuration import SimConfig
-from neurodamus.target_manager import TargetManager, TargetSpec
 from neurodamus.report import Report
 from neurodamus.report_parameters import create_report_parameters
-
-from typing import List, Dict, Tuple
-import pandas as pd
-import copy
+from neurodamus.target_manager import TargetManager, TargetSpec
 
 
-def merge_dicts(parent: dict, child: dict):
+def merge_dicts(parent: dict, child: dict):  # noqa: C901
     """Merge dictionaries recursively (in case of nested dicts) giving priority to child over parent
     for ties. Values of matching keys must match or a TypeError is raised.
 
     Special values/keys:
     - If a key in `child` has value "delete_field", it will be removed from the result.
-    - If a dictionary (nested or not) in `child` contains the key "override_field", it replaces the corresponding
-      `parent` sub-dictionary entirely (ignoring merging).
+    - If a dictionary (nested or not) in `child` contains the key "override_field",
+      it replaces the corresponding `parent` sub-dictionary entirely (ignoring merging).
 
     Imported from MultiscaleRun.
 
@@ -73,12 +70,13 @@ def merge_dicts(parent: dict, child: dict):
             return parent[k]
         if k not in parent:
             return child[k]
-        if type(parent[k]) is not type(child[k]):
-            if not isinstance(parent[k], (int, float)) or not isinstance(child[k], (int, float)):
-                raise TypeError(
-                    f"Field type missmatch for the values of key {k}: "
-                    f"{parent[k]} ({type(parent[k])}) != {child[k]} ({type(child[k])})"
-                )
+        if type(parent[k]) is not type(child[k]) and not (
+            isinstance(parent[k], (int, float)) and isinstance(child[k], (int, float))
+        ):
+            raise TypeError(
+                f"Field type missmatch for the values of key {k}: "
+                f"{parent[k]} ({type(parent[k])}) != {child[k]} ({type(child[k])})"
+            )
         if isinstance(parent[k], dict):
             if "override_field" in child[k]:
                 return child[k]
@@ -86,26 +84,32 @@ def merge_dicts(parent: dict, child: dict):
             return merge_dicts(parent[k], child[k])
         return child[k]
 
-    ans = {
-        k: merge_vals(k, parent, child)
-        for k in set(parent) | set(child)
-        if not isinstance(child, dict) or k not in child or child[k] != "delete_field"
-    } if "override_field" not in child else copy.deepcopy(child)
+    ans = (
+        {
+            k: merge_vals(k, parent, child)
+            for k in set(parent) | set(child)
+            if not isinstance(child, dict) or k not in child or child[k] != "delete_field"
+        }
+        if "override_field" not in child
+        else copy.deepcopy(child)
+    )
     sanitize_dict(ans)
     return ans
+
 
 def defaultdict_to_standard_types(obj):
     """Recursively converts defaultdicts with iterable values to standard Python types."""
     if isinstance(obj, (defaultdict, dict)):
         return {key: defaultdict_to_standard_types(value) for key, value in obj.items()}
-    elif isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
+    if isinstance(obj, Iterable) and not isinstance(obj, (str, bytes)):
         return [defaultdict_to_standard_types(x) for x in obj]
-    elif isinstance(obj, np.generic):  # convert NumPy scalars to Python scalars
+    if isinstance(obj, np.generic):  # convert NumPy scalars to Python scalars
         return obj.item()
     return obj
 
+
 def get_edge_data(nd, src_pop: str, src_rawgid: int, tgt_pop: str, tgt_rawgid: int):
-    """ Convenience function to retrieve gids, edges, and selection.
+    """Convenience function to retrieve gids, edges, and selection.
 
     Nd is neurodamus.code.Neurodamus
     """
@@ -115,11 +119,13 @@ def get_edge_data(nd, src_pop: str, src_rawgid: int, tgt_pop: str, tgt_rawgid: i
     src_gid = src_rawgid + src_pop_offset
 
     if src_pop == tgt_pop:
-        edges_file, edge_pop = \
-            nd.circuits.get_edge_managers(tgt_pop, tgt_pop)[0].circuit_conf.nrnPath.split(":")
+        edges_file, edge_pop = nd.circuits.get_edge_managers(tgt_pop, tgt_pop)[
+            0
+        ].circuit_conf.nrnPath.split(":")
     else:
-        edges_file, edge_pop = \
+        edges_file, edge_pop = (
             nd.circuits.get_edge_managers(src_pop, tgt_pop)[0].circuit_conf["Path"].split(":")
+        )
     edge_storage = EdgeStorage(edges_file)
     edges = edge_storage.open_population(edge_pop)
     selection = edges.afferent_edges(tgt_rawgid)
@@ -146,22 +152,18 @@ def compare_json_files(res_file: Path, ref_file: Path):
     Args:
         res_file (Path): The path to the result JSON file to compare.
         ref_file (Path): The path to the reference JSON file to compare against.
-
-    Raises:
-        AssertionError: If the two JSON files have different contents.
-        FileNotFoundError: If either of the provided file paths does not exist.
     """
     assert res_file.exists()
     assert ref_file.exists()
-    with open(res_file) as f_res:
+    with open(res_file, encoding="utf-8") as f_res:
         result = json.load(f_res)
-    with open(ref_file) as f_ref:
+    with open(ref_file, encoding="utf-8") as f_ref:
         reference = json.load(f_ref)
     assert result == reference
 
 
 def check_directory(dir_name: "Path | str"):
-    """ Check if a directory exists and is not empty """
+    """Check if a directory exists and is not empty"""
     dir_name = Path(dir_name)
     assert dir_name.is_dir(), f"{dir_name} doesn't exist"
     assert any(dir_name.iterdir()), f"{dir_name} is empty"
@@ -208,19 +210,13 @@ def check_netcon(src_gid, nc_id, nc, edges, selection, **kwargs):
         **kwargs: Optional arguments to override default values
         for conductance, delay, spike threshold, and initial voltage.
 
-    Raises:
-        AssertionError: If any of the attribute checks fail.
     """
 
     assert nc.srcgid() == src_gid
     assert np.isclose(
         nc.weight[0],
-        kwargs.get(
-            "weight",
-            1.0) *
-        edges.get_attribute(
-            "conductance",
-            selection)[nc_id])
+        kwargs.get("weight", 1.0) * edges.get_attribute("conductance", selection)[nc_id],
+    )
     assert np.isclose(nc.delay, _get_attr("delay", kwargs, edges, selection, nc_id))
     assert np.isclose(nc.threshold, kwargs.get("spike_threshold", SimConfig.spike_threshold))
     assert np.isclose(nc.x, kwargs.get("v_init", SimConfig.v_init))
@@ -259,8 +255,6 @@ def check_synapse(syn, edges, selection, **kwargs):
                 Keys include `decay_time`, `u_syn`, `depression_time`,
                 `facilitation_time`, and `n_rrp_vesicles`.
 
-    Raises:
-        AssertionError: If any of the synaptic attributes do not match the expected values.
     """
 
     expected_types = ["ProbGABAAB_EMS", "ProbAMPANMDA_EMS"]
@@ -291,7 +285,8 @@ def check_synapse(syn, edges, selection, **kwargs):
     if "NMDA_ratio" in kwargs and hasattr(syn, "NMDA_ratio"):
         assert np.isclose(syn.NMDA_ratio, kwargs["NMDA_ratio"])
 
-def record_compartment_reports(target_manager: TargetManager, nd_t=0):
+
+def record_compartment_reports(target_manager: TargetManager, nd_t=0):  # noqa: PLR0914
     """For compartment report, retrieve segments, and record the pointer of reporting variable
     More details in NEURON Vector.record()
 
@@ -299,14 +294,21 @@ def record_compartment_reports(target_manager: TargetManager, nd_t=0):
     """
     ascii_recorders = {}
 
-
     reports_conf = {name: conf for name, conf in SimConfig.reports.items() if conf.enabled}
 
     for rep_name, rep_conf in reports_conf.items():
         target_spec = TargetSpec(rep_conf.cells, None)
         target = target_manager.get_target(target_spec)
 
-        rep_params = create_report_parameters(sim_end=SimConfig.run_conf.tstop, nd_t=nd_t, output_root=SimConfig.output_root, rep_name=rep_name, rep_conf=rep_conf, target=target, buffer_size=8)
+        rep_params = create_report_parameters(
+            sim_end=SimConfig.run_conf.tstop,
+            nd_t=nd_t,
+            output_root=SimConfig.output_root,
+            rep_name=rep_name,
+            rep_conf=rep_conf,
+            target=target,
+            buffer_size=8,
+        )
 
         if rep_params.type != SimulationConfig.Report.Type.compartment:
             continue
@@ -315,10 +317,18 @@ def record_compartment_reports(target_manager: TargetManager, nd_t=0):
         tvec.indgen(rep_params.start, rep_params.end, rep_params.dt)
 
         sections, compartments = rep_params.sections, rep_params.compartments
-        if rep_params.type == SimulationConfig.Report.Type.summation and sections == SimulationConfig.Report.Sections.soma:
-            sections, compartments = SimulationConfig.Report.Sections.all, SimulationConfig.Report.Compartments.all
+        if (
+            rep_params.type == SimulationConfig.Report.Type.summation
+            and sections == SimulationConfig.Report.Sections.soma
+        ):
+            sections, compartments = (
+                SimulationConfig.Report.Sections.all,
+                SimulationConfig.Report.Compartments.all,
+            )
         points = rep_params.target.get_point_list(
-            cell_manager=target_manager._cell_manager, section_type=sections, compartment_type=compartments
+            cell_manager=target_manager._cell_manager,
+            section_type=sections,
+            compartment_type=compartments,
         )
 
         recorder = []
@@ -338,7 +348,7 @@ def record_compartment_reports(target_manager: TargetManager, nd_t=0):
                 trace = Nd.Vector()
                 trace.record(var_refs[0], tvec)
                 segname = str(section(x))
-                segname = segname[segname.find(".") + 1:]
+                segname = segname[segname.find(".") + 1 :]
                 recorder.append((gid, segname, trace))
 
         ascii_recorders[rep_name] = (recorder, tvec)
@@ -349,7 +359,7 @@ def write_ascii_reports(ascii_recorders, output_path):
     """Write out the report in ASCII format"""
     for rep_name, (recorder, tvec) in ascii_recorders.items():
         filename = Path(output_path) / (rep_name + ".txt")
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(f"{'cell_id':<10}{'seg_name':<20}{'time':<20}{'data':<20}\n")
             for gid, secname, data_vec in recorder:
                 f.writelines(
@@ -361,10 +371,10 @@ def write_ascii_reports(ascii_recorders, output_path):
 
 
 def read_ascii_report(filename):
-    """Read an ASCII report and return report data in format:(gid, seg_name, time, report_variable)
-    """
+    """Read an ASCII report and return report data in format:
+    (gid, seg_name, time, report_variable)"""
     data_vec = []
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         next(f)  # skip header
         for line in f:
             gid, seg_name, time, data = line.split()
@@ -373,7 +383,7 @@ def read_ascii_report(filename):
 
 
 def read_sonata_spike_file(spike_file):
-    """ Read a spike file and return the traces """
+    """Read a spike file and return the traces"""
     spikes = SpikeReader(spike_file)
     pop_name = spikes.get_population_names()[0]
     data = spikes[pop_name].get()
@@ -396,10 +406,28 @@ def compare_outdat_files(file1, file2, start_time=None, end_time=None):
 
     return np.array_equal(np.sort(events1, axis=0), np.sort(events2, axis=0))
 
-class ReportReader:
+
+def f_cos(t, freq, phase, amp):
+    """compute the cosine value"""
+    return amp * np.cos(2 * np.pi * freq / 1000 * t + phase)
+
+
+def make_ramp_envelope(t_vec, ramp_up_time, ramp_down_time, duration):
+    """With a given time vector, return a vector taking into account ramp up and down time"""
+    envelope = np.ones(len(t_vec))
+    envelope = np.where(t_vec < ramp_up_time, t_vec / ramp_up_time, envelope)
+    envelope = np.where(
+        t_vec > ramp_up_time + duration,
+        1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time,
+        envelope,
+    )
+    return envelope
+
+
+class ReportReader:  # noqa: PLW1641
     def __init__(self, file: str):
         self._reader = ElementReportReader(file)
-        self.populations: Dict[str, Tuple[List[int], pd.DataFrame]] = {}
+        self.populations: dict[str, tuple[list[int], pd.DataFrame]] = {}
 
         for name in sorted(self._reader.get_population_names()):
             pop = self._reader[name]
@@ -408,9 +436,7 @@ class ReportReader:
 
             # stable sort for ties
             df = pd.DataFrame(
-                data.data,
-                columns=pd.MultiIndex.from_arrays(data.ids.T),
-                index=data.times
+                data.data, columns=pd.MultiIndex.from_arrays(data.ids.T), index=data.times
             ).sort_index(axis=1)
 
             self.populations[name] = (node_ids, df)
@@ -439,7 +465,7 @@ class ReportReader:
 
             # coreneuron has sometimes garbage for the first line
             # erro thresholds as for old bb5 itegration report tests
-            if not np.allclose(df1.values[1:], df2.values[1:], rtol=rtol, atol=atol):
+            if not np.allclose(df1.to_numpy()[1:], df2.to_numpy()[1:], rtol=rtol, atol=atol):
                 return False
 
         return True
@@ -451,10 +477,9 @@ class ReportReader:
             if isinstance(df.columns, pd.MultiIndex) and df.columns.nlevels > 1:
                 new_df = df.T.groupby(level=0).sum().T
                 # force 2-level MultiIndex with second level zeros
-                new_df.columns = pd.MultiIndex.from_arrays([
-                    new_df.columns,
-                    [0] * len(new_df.columns)
-                ])
+                new_df.columns = pd.MultiIndex.from_arrays(
+                    [new_df.columns, [0] * len(new_df.columns)]
+                )
                 new_nodes = sorted(new_df.columns.get_level_values(0).tolist())
             else:
                 new_df = df.copy()
@@ -464,16 +489,16 @@ class ReportReader:
 
         self.populations = new_populations
 
-    def reduce_to_compartment_set_report(self, population: str, positions: List[int]) -> None:
+    def reduce_to_compartment_set_report(self, population: str, positions: list[int]) -> None:
         """
         Create and return a new ReportReader reduced to the selected columns
-        of a population’s compartment set report. The original object is not
+        of a population's compartment set report. The original object is not
         modified
         """
         if population not in self.populations:
             raise ValueError(f"Population '{population}' not found in report.")
 
-        nodes, df = self.populations[population]
+        _nodes, df = self.populations[population]
 
         if not isinstance(df.columns, pd.MultiIndex) or df.columns.nlevels != 2:
             raise ValueError("Expected columns to be a 2-level MultiIndex.")
@@ -483,7 +508,7 @@ class ReportReader:
 
         # No need to rebuild MultiIndex — iloc preserves it
         # Extract node IDs from level 0 (with repetitions, in order)
-        new_nodes = sorted(list(set([col[0] for col in new_df.columns])))
+        new_nodes = sorted({col[0] for col in new_df.columns})
 
         new_reader = ReportReader.__new__(ReportReader)  # bypass __init__
         new_reader._reader = self._reader
@@ -495,8 +520,12 @@ class ReportReader:
         lines = [f"ReportReader with {len(self.populations)} populations:"]
         for name, (nodes, df) in self.populations.items():
             nodes_str = ", ".join(str(n) for n in nodes)
-            lines.append(f"  - {name}: {len(nodes)} nodes, shape={df.shape}")
-            lines.append(f"      node_ids: [{nodes_str}]")
+            lines.extend(
+                [
+                    f"  - {name}: {len(nodes)} nodes, shape={df.shape}",
+                    f"      node_ids: [{nodes_str}]",
+                ]
+            )
 
             columns = df.columns
             cols_str = ", ".join(f"({a},{b})" for a, b in columns)
@@ -541,5 +570,3 @@ class ReportReader:
         new_report._reader = None  # or keep from self if needed
 
         return new_report
-
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -441,7 +441,7 @@ def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
         t_vec = tot_tvec[start_idx:stop_idx] - delay
         ramp_vec = _make_ramp_envelope(t_vec, ramp_up, ramp_down, dur)
         ref[start_idx:stop_idx] += (
-            _f_cos(t_vec, field.frequency, field.phase, efi.get_potential_amplitude(idx)) * ramp_vec
+            _f_cos(t_vec, field.frequency, field.phase, efi.get_peak_potential(idx)) * ramp_vec
         )
 
         # potential is always 0 at t=0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from libsonata import EdgeStorage, ElementReportReader, SimulationConfig, SpikeR
 
 from neurodamus.core import NeuronWrapper as Nd
 from neurodamus.core.configuration import SimConfig
-from neurodamus.core.stimuli import EField
+from neurodamus.io.sonata_config import EField
 from neurodamus.report import Report
 from neurodamus.report_parameters import create_report_parameters
 from neurodamus.target_manager import TargetManager, TargetSpec

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -422,14 +422,13 @@ def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
 
     def _make_ramp_envelope(t_vec, ramp_up_time, ramp_down_time, duration):
         """With a given time vector, return a vector taking into account ramp up and down time"""
-        envelope = np.ones(len(t_vec))
-        envelope = np.where(t_vec < ramp_up_time, t_vec / ramp_up_time, envelope)
-        envelope = np.where(
-            t_vec > ramp_up_time + duration,
-            1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time,
-            envelope,
+        ramp_up = np.clip(t_vec / ramp_up_time, 0, 1) if ramp_up_time > 0 else np.ones(len(t_vec))
+        ramp_down = (
+            np.clip(1 - (t_vec - (ramp_up_time + duration)) / ramp_down_time, 0, 1)
+            if ramp_down_time > 0
+            else np.ones(len(t_vec))
         )
-        return envelope
+        return np.minimum(ramp_up, ramp_down)
 
     ref_dend = np.zeros(len(tot_tvec))
     for idx, field in enumerate(fields):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,41 @@ from neurodamus.report_parameters import create_report_parameters
 from neurodamus.target_manager import TargetManager, TargetSpec
 
 
-def merge_dicts(parent: dict, child: dict):  # noqa: C901
+def _merge_vals(k, parent: dict, child: dict):
+    """Merging logic.
+
+    Args:
+        k (key type): the key can be in either parent, child or both.
+        parent: parent dict.
+        child: child dict (priority).
+
+    Raises:
+        TypeError: in case the key is present in both parent and child and the type missmatches.
+
+    Returns:
+        value type: merged version of the values possibly found in child and/or parent.
+    """
+
+    if k not in child:
+        return parent[k]
+    if k not in parent:
+        return child[k]
+    if type(parent[k]) is not type(child[k]) and not (
+        isinstance(parent[k], (int, float)) and isinstance(child[k], (int, float))
+    ):
+        raise TypeError(
+            f"Field type missmatch for the values of key {k}: "
+            f"{parent[k]} ({type(parent[k])}) != {child[k]} ({type(child[k])})"
+        )
+    if isinstance(parent[k], dict):
+        if "override_field" in child[k]:
+            return child[k]
+
+        return merge_dicts(parent[k], child[k])
+    return child[k]
+
+
+def merge_dicts(parent: dict, child: dict):
     """Merge dictionaries recursively (in case of nested dicts) giving priority to child over parent
     for ties. Values of matching keys must match or a TypeError is raised.
 
@@ -52,42 +86,9 @@ def merge_dicts(parent: dict, child: dict):  # noqa: C901
             for item in d:
                 sanitize_dict(item)
 
-    def merge_vals(k, parent: dict, child: dict):
-        """Merging logic.
-
-        Args:
-            k (key type): the key can be in either parent, child or both.
-            parent: parent dict.
-            child: child dict (priority).
-
-        Raises:
-            TypeError: in case the key is present in both parent and child and the type missmatches.
-
-        Returns:
-            value type: merged version of the values possibly found in child and/or parent.
-        """
-
-        if k not in child:
-            return parent[k]
-        if k not in parent:
-            return child[k]
-        if type(parent[k]) is not type(child[k]) and not (
-            isinstance(parent[k], (int, float)) and isinstance(child[k], (int, float))
-        ):
-            raise TypeError(
-                f"Field type missmatch for the values of key {k}: "
-                f"{parent[k]} ({type(parent[k])}) != {child[k]} ({type(child[k])})"
-            )
-        if isinstance(parent[k], dict):
-            if "override_field" in child[k]:
-                return child[k]
-
-            return merge_dicts(parent[k], child[k])
-        return child[k]
-
     ans = (
         {
-            k: merge_vals(k, parent, child)
+            k: _merge_vals(k, parent, child)
             for k in set(parent) | set(child)
             if not isinstance(child, dict) or k not in child or child[k] != "delete_field"
         }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -430,7 +430,7 @@ def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
         )
         return np.minimum(ramp_up, ramp_down)
 
-    ref_dend = np.zeros(len(tot_tvec))
+    ref = np.zeros(len(tot_tvec))
     for idx, field in enumerate(fields):
         dur = field.duration
         delay = field.delay
@@ -440,13 +440,13 @@ def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
         stop_idx = np.searchsorted(tot_tvec, dur + ramp_up + ramp_down + delay)
         t_vec = tot_tvec[start_idx:stop_idx] - delay
         ramp_vec = _make_ramp_envelope(t_vec, ramp_up, ramp_down, dur)
-        ref_dend[start_idx:stop_idx] += (
+        ref[start_idx:stop_idx] += (
             _f_cos(t_vec, field.frequency, field.phase, efi.get_potential_amplitude(idx)) * ramp_vec
         )
 
         # potential is always 0 at t=0
-        ref_dend[0] = 0
-    return ref_dend
+        ref[0] = 0
+    return ref
 
 
 class ReportReader:  # noqa: PLW1641


### PR DESCRIPTION
## Context
Part 2 for https://github.com/openbraininstitute/prod-circuit-simulation/issues/172, combine multiple  SpatiallyUniformEField stimulus blocks amd add electric fields into the EFieldIntegrator mechanism.

## Scope
1. In `stimuli.py`, each cell has an object `ElectrodeSource` which contains a list of EFields which are parsed per SpatiallyUniformEField stimulus. 
2. In case of mulitple SpatiallyUniformEField stimulus blocks, for every overlapping cell, its `ElectrodeSource` 's efields list is extended with the efields from the new block thanks to the singleton design pattern.
3. After looping over the stimulus blocks, call each cell's `ElectrodeSource.apply_segment_potentialsply`  that creates a `EFieldIntegrator` mod object with the list of EFields
4. Refactor `efield_integrator.mod` to take a list of e-fields, and loop over the e-fields during `BEFORE BREAKPOINT` process. 

## Testing
1. Include `tests/unit/test_multiple_extracellular_stimuli.py`
2. Refactor and compute references for tests regarding extracellular stimulus, fixes #523 

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
