### PR TITLE
Simplify EFieldIntegrator: pre-compute peak potential on Python side

### DIFF
--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -531,9 +531,7 @@ class ElectrodeSource:
             n_fields = len(self.efields)
             freq_vector = Nd.h.Vector(n_fields)
             phase_vector = Nd.h.Vector(n_fields)
-            x_vec = Nd.h.Vector(n_fields)
-            y_vec = Nd.h.Vector(n_fields)
-            z_vec = Nd.h.Vector(n_fields)
+            peak_potential_vec = Nd.h.Vector(n_fields)
             delay_vec = Nd.h.Vector(n_fields)
             duration_vec = Nd.h.Vector(n_fields)
             rup_vec = Nd.h.Vector(n_fields)
@@ -542,9 +540,12 @@ class ElectrodeSource:
             for i, field in enumerate(self.efields):
                 freq_vector.x[i] = field.frequency
                 phase_vector.x[i] = field.phase
-                x_vec.x[i] = field.ex * displacement[0]
-                y_vec.x[i] = field.ey * displacement[1]
-                z_vec.x[i] = field.ez * displacement[2]
+                # dot product E·d in V, converted to mV (* 1e3)
+                peak_potential_vec.x[i] = 1e3 * (
+                    field.ex * displacement[0]
+                    + field.ey * displacement[1]
+                    + field.ez * displacement[2]
+                )
                 delay_vec.x[i] = field.delay
                 duration_vec.x[i] = field.duration
                 rup_vec.x[i] = field.ramp_up_time
@@ -557,9 +558,7 @@ class ElectrodeSource:
                 duration_vec,
                 rup_vec,
                 rdown_vec,
-                x_vec,
-                y_vec,
-                z_vec,
+                peak_potential_vec,
                 phase_vector,
                 freq_vector,
             )

--- a/neurodamus/data/mod/efield_integrator.mod
+++ b/neurodamus/data/mod/efield_integrator.mod
@@ -1,7 +1,7 @@
 NEURON {
     POINT_PROCESS EFieldIntegrator
     POINTER e_ext
-    POINTER phase, frequency, X, Y, Z, delay, duration, ramp_up, ramp_down
+    POINTER phase, frequency, peak_potential, delay, duration, ramp_up, ramp_down
     RANGE enabled  : set when e_ext pointer is assigned, this prevents mcomplex calculation to access unassigned e_ext reference
 }
 
@@ -20,9 +20,7 @@ ASSIGNED {
     ramp_down
     phase
     frequency
-    X
-    Y
-    Z
+    peak_potential
     enabled
 }
 
@@ -33,10 +31,8 @@ INITIAL {
 
 VERBATIM
 #ifndef CORENEURON_BUILD
-    if( !_p_X ) {
-        _p_X = vector_new1(0);
-        _p_Y = vector_new1(0);
-        _p_Z = vector_new1(0);
+    if( !_p_peak_potential ) {
+        _p_peak_potential = vector_new1(0);
         _p_phase = vector_new1(0);
         _p_frequency = vector_new1(0);
         _p_delay = vector_new1(0);
@@ -50,7 +46,7 @@ ENDVERBATIM
 
 PROCEDURE add_electrode_source() {
     : receive data elements for an ElectrodeSource
-    : vectors for n fields: delay, duration, ramp_up_time, ramp_down_time, x, y, z, freq, phase,
+    : vectors for n fields: delay, duration, ramp_up_time, ramp_down_time, peak_potential, freq, phase
 
 VERBATIM
 #ifndef CORENEURON_BUILD
@@ -58,16 +54,12 @@ VERBATIM
     auto* argduration = vector_arg(2);
     auto* argramp_up = vector_arg(3);
     auto* argramp_down = vector_arg(4);
-    auto* argX = vector_arg(5);
-    auto* argY = vector_arg(6);
-    auto* argZ = vector_arg(7);
-    auto* argphase = vector_arg(8);
-    auto* argfreq = vector_arg(9);
+    auto* argpeak_potential = vector_arg(5);
+    auto* argphase = vector_arg(6);
+    auto* argfreq = vector_arg(7);
 
-    int size = vector_capacity(argX);
-    _p_X = vector_new1(size);
-    _p_Y = vector_new1(size);
-    _p_Z = vector_new1(size);
+    int size = vector_capacity(argpeak_potential);
+    _p_peak_potential = vector_new1(size);
     _p_phase = vector_new1(size);
     _p_frequency = vector_new1(size);
     _p_delay = vector_new1(size);
@@ -75,9 +67,7 @@ VERBATIM
     _p_ramp_up = vector_new1(size);
     _p_ramp_down = vector_new1(size);
 
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
+    auto *vpeak = *reinterpret_cast<IvocVect**>(&_p_peak_potential);
     auto *vphase = *reinterpret_cast<IvocVect**>(&_p_phase);
     auto *vfreq = *reinterpret_cast<IvocVect**>(&_p_frequency);
     auto *vdelay = *reinterpret_cast<IvocVect**>(&_p_delay);
@@ -86,9 +76,7 @@ VERBATIM
     auto *vramp_down = *reinterpret_cast<IvocVect**>(&_p_ramp_down);
 
     for( int i=0; i<size; i++ ) {
-        vector_vec(vX)[i] = vector_vec(argX)[i];
-        vector_vec(vY)[i] = vector_vec(argY)[i];
-        vector_vec(vZ)[i] = vector_vec(argZ)[i];
+        vector_vec(vpeak)[i] = vector_vec(argpeak_potential)[i];
         vector_vec(vphase)[i] = vector_vec(argphase)[i];
         vector_vec(vfreq)[i] = vector_vec(argfreq)[i];
         vector_vec(vdelay)[i] = vector_vec(argdelay)[i];
@@ -100,14 +88,13 @@ VERBATIM
 ENDVERBATIM
 }
 
-FUNCTION get_potential_amplitude(i) {
-    : get potential amplitude for ith eletric field, in mV
+FUNCTION get_peak_potential(i) {
+    : get peak potential for ith electric field, in mV
+    : this is the dot product E dot d (field * displacement) pre-computed on the Python side
 VERBATIM
     int idx = (int)_li;
-    auto *vX = *reinterpret_cast<IvocVect**>(&_p_X);
-    auto *vY = *reinterpret_cast<IvocVect**>(&_p_Y);
-    auto *vZ = *reinterpret_cast<IvocVect**>(&_p_Z);
-    _lget_potential_amplitude = 1e3 * (vector_vec(vX)[idx] + vector_vec(vY)[idx] + vector_vec(vZ)[idx]);
+    auto *vpeak = *reinterpret_cast<IvocVect**>(&_p_peak_potential);
+    _lget_peak_potential = vector_vec(vpeak)[idx];
 ENDVERBATIM
 }
 
@@ -139,7 +126,7 @@ VERBATIM
                 ramp_factor = 1 - (t - (cur_delay + cur_ramp_up + cur_duration)) / cur_ramp_down;
             }
             double wavefactor = cos(2 * PI * vector_vec(vfreq)[i] / 1000 * (t-cur_delay) + vector_vec(vphase)[i]);
-            _lefield_accum += ramp_factor * get_potential_amplitude(i) * wavefactor;
+            _lefield_accum += ramp_factor * get_peak_potential(i) * wavefactor;
         }
     }
 #endif
@@ -151,4 +138,3 @@ ENDVERBATIM
 
 : currently, extracellular stimulus is not supported by coreneuron, so will
 : skip using BBCOREPOINTER and bbcore_write/bbcore_read
-

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -89,8 +89,8 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)
     assert len(es.efields) == 2
     dend_efi = es.segment_efield_integrators[3]
-    assert np.isclose(dend_efi.get_potential_amplitude(0), -0.505702)
-    assert np.isclose(dend_efi.get_potential_amplitude(1), -0.964335)
+    assert np.isclose(dend_efi.get_peak_potential(0), -0.505702)
+    assert np.isclose(dend_efi.get_peak_potential(1), -0.964335)
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     ref_soma = np.zeros(len(tot_tvec))

--- a/tests/unit/test_single_extracellular_stimulus.py
+++ b/tests/unit/test_single_extracellular_stimulus.py
@@ -110,10 +110,10 @@ def test_one_field_noramp(create_tmp_simulation_config_file):
 
     tot_tvec = np.concatenate([[0], np.arange(Nd.dt / 2, Nd.tstop, Nd.dt)])
     assert len(es.efields) == 1
-    assert np.isclose(es.segment_efield_integrators[0].get_potential_amplitude(0), 0)
+    assert np.isclose(es.segment_efield_integrators[0].get_peak_potential(0), 0)
     ref_soma = np.zeros(len(tot_tvec))
     efi_dend = es.segment_efield_integrators[3]
-    assert np.isclose(efi_dend.get_potential_amplitude(0), -0.505702)
+    assert np.isclose(efi_dend.get_peak_potential(0), -0.505702)
     ref_dend = get_expected_extracellular_potentials(tot_tvec, efi_dend, es.efields)
     npt.assert_allclose(rec_soma, ref_soma)
     npt.assert_allclose(rec_dend, ref_dend)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -441,7 +441,7 @@ def get_expected_extracellular_potentials(tot_tvec, efi, fields: list[EField]):
         t_vec = tot_tvec[start_idx:stop_idx] - delay
         ramp_vec = _make_ramp_envelope(t_vec, ramp_up, ramp_down, dur)
         ref_dend[start_idx:stop_idx] += (
-            _f_cos(t_vec, field.frequency, field.phase, efi.get_potential_amplitude(idx)) * ramp_vec
+            _f_cos(t_vec, field.frequency, field.phase, efi.get_peak_potential(idx)) * ramp_vec
         )
 
         # potential is always 0 at t=0


### PR DESCRIPTION
## Scope

Replace the 3 separate X, Y, Z vectors in the mod file with a single peak_potential vector. The dot product E·d is now fully computed in Python before being passed to the mechanism, removing redundant storage and making the mod file's intent clearer.

Rename get_potential_amplitude -> get_peak_potential to better reflect that the value is the unscaled peak potential (before ramp/cosine).

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
