### PR TITLE
Avoid shared reference in ElectrodeSource.efields to fix mulitple elecric fields stimulus on mulitple cells

### DIFF
--- a/neurodamus/core/stimuli.py
+++ b/neurodamus/core/stimuli.py
@@ -502,7 +502,7 @@ class ElectrodeSource:
     def __init__(self, efields: list[EField]):
         # list of EFieldIntegrator mechs attached to segments, required to avoid garbage collection
         self.segment_efield_integrators = []
-        self.efields = efields
+        self.efields = efields.copy()  # copy to avoid shared reference when combined via __iadd__
 
     def apply_segment_potentials(self, segment_displacements):
         """Apply potentials to segment.extracellular._ref_e

--- a/tests/unit/test_multiple_extracellular_stimuli.py
+++ b/tests/unit/test_multiple_extracellular_stimuli.py
@@ -32,7 +32,7 @@ from neurodamus.stimulus_manager import SpatiallyUniformEField
                         "module": "spatially_uniform_e_field",
                         "delay": 0,
                         "duration": 5,
-                        "node_set": "RingA_Cell0",
+                        "node_set": "RingA",
                         "fields": [
                             {"Ex": 50, "Ey": -25, "Ez": 75, "frequency": 100, "phase": 1.570796},
                         ],
@@ -44,7 +44,7 @@ from neurodamus.stimulus_manager import SpatiallyUniformEField
                         "module": "spatially_uniform_e_field",
                         "delay": 0,
                         "duration": 10,
-                        "node_set": "RingA_Cell0",
+                        "node_set": "RingA",
                         "fields": [
                             {"Ex": 100, "Ey": -50, "Ez": 50, "frequency": 0},
                         ],
@@ -83,7 +83,7 @@ def test_two_stimulus_blocks(create_tmp_simulation_config_file):
     Nd.finitialize()  # reinit for the recordings to be registered
     n.run()
 
-    assert list(stimulus.stimList.keys()) == [0]
+    assert list(stimulus.stimList.keys()) == [0, 1, 2]
     es = stimulus.stimList[0]
     assert isinstance(es, ElectrodeSource)
     assert len(es.segment_efield_integrators) == sum(sec.nseg for sec in cellref.all)


### PR DESCRIPTION
## Context
Fixes #538 
The current `ElectrodeSource.efields` for each cell is instantiated with a shared reference.  At the time of `__iadd__`, `ElectrodeSource.efields` gets extended with the e-fields from the 2nd spatially_uniform_e_field input. If it is shared reference, `ElectrodeSource.efields` of cell A gets extended at the time of `__iadd__` for cell B, cell C ... etc. That's wrong. 
This PR makes `ElectrodeSource.efields` to hold an independent copy.


## Testing
1: `tests/unit/test_multiple_extracellular_stimuli.py`: change the input target to the same muiltiple cells that could reveal the issue.

## Review
* [ ] PR description is complete
* [ ] Coding style (imports, function length, New functions, classes or files) are good
* [ ] Unit/Scientific test added
* [ ] Updated Readme, in-code, developer documentation
