### PR TITLE
Publish to PyPI on GitHub Release

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/lint_check.yml
+++ b/.github/workflows/lint_check.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
 
     - name: Install tox
       run: pip install tox

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -1,46 +1,58 @@
-name: Neurodamus Wheels
+name: Publish to PyPI
 
-on: [pull_request, push, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   wheel:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python_version: [3.11]
+        python_version: ["3.11"]
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
+
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 500
+          fetch-depth: 0  # needed for hatch-vcs to resolve version from tags
+
       - name: Build Wheel
         run: |
           cd $GITHUB_WORKSPACE
           python${{ matrix.python_version }} -m pip install --upgrade build
-          # build wheel
           python${{ matrix.python_version }} -m build .
+
       - name: Test Wheel
         run: |
           cd $GITHUB_WORKSPACE
           pip3 install tox
           DIST_FILE=`ls dist/*whl` && tox --installpkg=$DIST_FILE -e ${{ matrix.python_version }}
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@v7
         with:
           name: release-artifacts-${{ matrix.python_version }}-${{ strategy.job-index }}
           path: ./dist/*
+
   pypi-publish:
     runs-on: ubuntu-22.04
     needs: [wheel]
-    # IMPORTANT: this permission is mandatory for trusted publishing
     permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Download artifacts produced by the wheel job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: release-artifacts*
           path: dist/
@@ -50,8 +62,7 @@ jobs:
         run: ls -R
         working-directory: dist
 
-      - name: Upload Wheel
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages_dir: dist/

--- a/.github/workflows/publish_wheels.yml
+++ b/.github/workflows/publish_wheels.yml
@@ -12,14 +12,11 @@ on:
 jobs:
   wheel:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python_version: ["3.11"]
     steps:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: "3.11"
 
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -28,19 +25,17 @@ jobs:
 
       - name: Build Wheel
         run: |
-          cd $GITHUB_WORKSPACE
-          python${{ matrix.python_version }} -m pip install --upgrade build
-          python${{ matrix.python_version }} -m build .
+          python -m pip install --upgrade build
+          python -m build .
 
       - name: Test Wheel
         run: |
-          cd $GITHUB_WORKSPACE
-          pip3 install tox
-          DIST_FILE=`ls dist/*whl` && tox --installpkg=$DIST_FILE -e ${{ matrix.python_version }}
+          pip install tox
+          DIST_FILE=$(ls dist/*whl) && tox --installpkg=$DIST_FILE -e 3.11
 
       - uses: actions/upload-artifact@v7
         with:
-          name: release-artifacts-${{ matrix.python_version }}-${{ strategy.job-index }}
+          name: release-artifacts
           path: ./dist/*
 
   pypi-publish:
@@ -54,9 +49,8 @@ jobs:
       - name: Download artifacts produced by the wheel job
         uses: actions/download-artifact@v8
         with:
-          pattern: release-artifacts*
+          name: release-artifacts
           path: dist/
-          merge-multiple: true
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/simulation_test.yml
+++ b/.github/workflows/simulation_test.yml
@@ -67,7 +67,7 @@ jobs:
       run: echo "version=$(python -c 'import platform; print(platform.python_version())')" >> $GITHUB_OUTPUT
 
     - name: Checkout neurodamus repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
@@ -112,7 +112,7 @@ jobs:
 
     - name: Cache python virtual env
       id: cache-venv
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-venv
       with:
@@ -137,7 +137,7 @@ jobs:
 
     - name: Cache libsonatareport
       id: cache-libsonatareport
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-libsonatareport
       with:
@@ -158,7 +158,7 @@ jobs:
 
     - name: Cache NEURON
       id: cache-neuron
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-neuron
       with:


### PR DESCRIPTION
Aligns the publish workflow with BlueRecording and cookiecutter-python-lib:

- Trigger PyPI publish on GitHub Release (published) instead of tag push
- Scope push trigger to main branch only
- Use fetch-depth: 0 for reliable hatch-vcs version resolution
- Bump action versions (setup-python@v6, checkout@v6, upload-artifact@v7, download-artifact@v8)
- Move publish condition to job level to skip unnecessary steps
- Keep existing wheel test step

Requested by @eleftherioszisis . I also think that we should standardize this