### PR TITLE
Fix complex dtype crash in contour2centroid with NumPy 2.5.0+

### DIFF
--- a/neurodamus/morphio_wrapper.py
+++ b/neurodamus/morphio_wrapper.py
@@ -109,7 +109,7 @@ def contour2centroid(mean, points):
     # assuming (falsely in general) that the center is the mean
 
     points -= mean
-    eigen_values, eigen_vectors = eigh(np.dot(points.T, points))
+    _, eigen_vectors = eigh(np.dot(points.T, points))
 
     # To be consistent with NEURON eigen vector directions
     eigen_vectors *= -1

--- a/neurodamus/morphio_wrapper.py
+++ b/neurodamus/morphio_wrapper.py
@@ -114,11 +114,10 @@ def contour2centroid(mean, points):
     # To be consistent with NEURON eigen vector directions
     eigen_vectors *= -1
 
-    idx = np.argmax(eigen_values)
-    major = eigen_vectors[:, idx]
-    # minor is normal and in xy plane
-    idx = 3 - np.argmin(eigen_values) - np.argmax(eigen_values)
-    minor = eigen_vectors[:, idx]
+    # eigh returns eigenvalues in ascending order:
+    # [0]=smallest, [1]=middle, [2]=largest
+    major = eigen_vectors[:, 2]
+    minor = eigen_vectors[:, 1]
     minor[2] = 0
 
     sides, rads = get_sides(points, major, minor)

--- a/neurodamus/morphio_wrapper.py
+++ b/neurodamus/morphio_wrapper.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 
 import numpy as np
-from numpy.linalg import eig, norm
+from numpy.linalg import eigh, norm
 
 """
     [START] Implementations retrieved from nse/morph-tool (!= hpc/morpho-tool !!!)
@@ -109,7 +109,7 @@ def contour2centroid(mean, points):
     # assuming (falsely in general) that the center is the mean
 
     points -= mean
-    eigen_values, eigen_vectors = eig(np.dot(points.T, points))
+    eigen_values, eigen_vectors = eigh(np.dot(points.T, points))
 
     # To be consistent with NEURON eigen vector directions
     eigen_vectors *= -1


### PR DESCRIPTION
Fix: https://github.com/openbraininstitute/neurodamus/issues/559

`contour2centroid` in `morphio_wrapper.py` uses `numpy.linalg.eig` to decompose the covariance-like matrix `points.T @ points`. While this matrix is real and symmetric, `eig` (the general eigensolver) can return complex eigenvalues/eigenvectors due to floating-point perturbation. In NumPy < 2 this was silently cast to float downstream; NumPy 2.x raises:

```
TypeError: Cannot cast array data from dtype('complex128') to dtype('float64')
    according to the rule 'safe'
```

The crash occurs in `np.interp(new_major_coord, sides[0], rads[0])` because `sides` and `rads` inherit the complex dtype from the eigenvectors.

## Fix

Replace `eig` with `eigh` (the solver for symmetric/Hermitian matrices). Since `points.T @ points` is always real-symmetric, `eigh` is both mathematically correct and guarantees real-valued output.

opt: leverage this to pick biggest and smallest igenvalues since eigh returns them in order.

## Test

```
tests/unit/test_morphIOwrapper.py::test_section_names
```