### PR TITLE
CI: LD_PRELOAD libnrnmech on Linux for ctypes symbol visibility

### DIFF
--- a/ci/scripts/make-env.sh
+++ b/ci/scripts/make-env.sh
@@ -21,5 +21,10 @@ make-env() {
     export CORENEURONLIB=$INSTALL_DIR/$ARCH/libcorenrnmech.$LIB_EXT
     export NRNMECH_LIB_PATH=$INSTALL_DIR/$ARCH/libnrnmech.$LIB_EXT
     export PATH=$INSTALL_DIR/$ARCH:$PATH
+    # On Linux, NEURON loads libnrnmech via dlopen with RTLD_LOCAL, hiding its
+    # symbols from ctypes.CDLL(None). LD_PRELOAD forces global visibility.
+    if [[ \$(uname) == Linux ]]; then
+        export LD_PRELOAD=$INSTALL_DIR/$ARCH/libnrnmech.$LIB_EXT
+    fi
 _EOF
 }


### PR DESCRIPTION
On Linux, NEURON's `nrn_load_dll()` loads `libnrnmech.so` via `dlopen()` with `RTLD_LOCAL`. This means symbols defined in MOD files (specifically `sonata_report_helper_register_pre_record_callback` from `SonataReportHelper.mod`) are not visible in the process's global symbol table.

When neurodamus calls `ctypes.CDLL(None).sonata_report_helper_register_pre_record_callback`, it searches the global symbol table and fails with:

```
undefined symbol: sonata_report_helper_register_pre_record_callback
```

This only affects Linux. On macOS, dylibs use a flat namespace that makes all symbols globally visible regardless of how they were loaded.

The issue manifests when running with `target_simulator: NEURON` (not CoreNEURON, because the MOD file guards all reporting code with `#ifndef CORENEURON_BUILD`).

Fix: https://github.com/openbraininstitute/neurodamus/issues/570

## Fix

Add `LD_PRELOAD=$NRNMECH_LIB_PATH` to `env-neocortex.sh` on Linux. This forces `libnrnmech.so` to be loaded with global symbol visibility before NEURON's own `dlopen` call, making the symbol accessible via `ctypes.CDLL(None)`.

The preloaded library is the same one that would be loaded anyway, so there is no performance or correctness cost.