### PR TITLE
libsonata correctly handles `output_path`, make sure directory exists and update tests

### DIFF
--- a/neurodamus/core/_neurodamus.py
+++ b/neurodamus/core/_neurodamus.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import logging
 import os
 import sys
@@ -38,6 +39,7 @@ class _NeuronWrapper(_Neuron):
         # Init logging
         log_filename = log_filename or LOG_FILENAME
         if MPI.rank == 0:
+            Path(log_filename).parent.mkdir(exist_ok=True, parents=True)
             open(log_filename, "w", encoding="utf-8").close()  # Truncate
         MPI.barrier()  # Sync so that all processes see the file
         setup_logging(GlobalConfig.verbosity, log_filename, MPI.rank, use_color=log_use_color)

--- a/tests/unit/test_sonata_config.py
+++ b/tests/unit/test_sonata_config.py
@@ -211,8 +211,7 @@ def test_parse_connections(create_tmp_simulation_config):
 ], indirect=True)
 def test_parse_ouput(create_tmp_simulation_config):
     SimConfig.init(create_tmp_simulation_config, {})
-    # output section
-    assert SimConfig.run_conf.spikes_file == "spikes.h5"
+    assert SimConfig.run_conf.spikes_file == f"{create_tmp_simulation_config.base_path}/spikes.h5"
     assert SimConfig.run_conf.spikes_sort_order == libsonata.SimulationConfig.Output.SpikesSortOrder.by_time
 
 

--- a/tests/unit/test_sonata_output.py
+++ b/tests/unit/test_sonata_output.py
@@ -1,5 +1,7 @@
-import pytest
+import os
 from pathlib import Path
+
+import pytest
 
 pytestmark = pytest.mark.forked  # independent processes
 
@@ -9,6 +11,7 @@ pytestmark = pytest.mark.forked  # independent processes
         "simconfig_fixture": "sonata_config",
         "extra_config": {
             "output": {
+                "output_dir": ".",
                 "log_file": "my_pydamus.log"
             }
         }
@@ -19,7 +22,7 @@ def test_sonata_logfile(create_tmp_simulation_config_file):
     # create a tmp json file to test the user defined log_file
     _ = Node(create_tmp_simulation_config_file)
 
-    assert Path("my_pydamus.log").exists()
+    assert (Path(create_tmp_simulation_config_file).parent / "my_pydamus.log").exists()
 
 
 @pytest.mark.parametrize("create_tmp_simulation_config_file", [


### PR DESCRIPTION
Two fixes in libsonata mean the output locations are correctly handled now:
* https://github.com/openbraininstitute/libsonata/pull/61
* https://github.com/openbraininstitute/libsonata/pull/62